### PR TITLE
Ensure all fields get passed to controller as part of `fields` option

### DIFF
--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -31,7 +31,7 @@ var Wizard = function (steps, fields, settings) {
 
         options = _.clone(options);
 
-        options.fields = _.pick(fields, options.fields);
+        options.fields = _.object(options.fields, _.map(options.fields, function(f) { return fields[f]; }));
         options.steps = steps;
 
         // default template is the same as the pathname

--- a/test/helpers/controller.js
+++ b/test/helpers/controller.js
@@ -1,16 +1,21 @@
 var util = require('util'),
     EventEmitter = require('events').EventEmitter;
 
-module.exports = function (stub) {
+module.exports = function (options) {
+
+    options = options || {};
+    options.constructor = options.constructor || function () {};
+    options.requestHandler = options.requestHandler || function () {};
 
     var Controller = function () {
         this.options = {};
+        options.constructor.apply(null, arguments);
     };
 
     util.inherits(Controller, EventEmitter);
 
     Controller.prototype.requestHandler = function () {
-        return stub;
+        return options.requestHandler;
     };
 
     return Controller;

--- a/test/spec.wizard.js
+++ b/test/spec.wizard.js
@@ -15,7 +15,7 @@ describe('Form Wizard', function () {
             requestHandler = sinon.stub().yields();
             wizard = Wizard({
                 '/': {
-                    controller: StubController(requestHandler)
+                    controller: StubController({ requestHandler: requestHandler })
                 }
             }, {}, { name: 'test-wizard' });
         });
@@ -42,6 +42,26 @@ describe('Form Wizard', function () {
                 req.sessionModel.toJSON().should.eql({ name: 'John' });
                 done(err);
             });
+        });
+
+    });
+
+    describe('fields', function () {
+
+        it('includes all fields in fields option', function () {
+            var constructor = sinon.stub();
+            wizard = Wizard({
+                '/': {
+                    controller: StubController({ constructor: constructor }),
+                    fields: ['field1', 'field2']
+                }
+            }, { field1: { validate: 'required' } }, { name: 'test-wizard' });
+
+            constructor.args[0][0].fields.should.eql({
+                field1: { validate: 'required' },
+                field2: undefined
+            });
+
         });
 
     });


### PR DESCRIPTION
I should probably start PR-ing things now this is actually being used for things...

Previously only fields which had a corresponding entry in the fields map were being included in the object passed into the controller as a fields option. Using a slightly more convoluted method to retrieve these from the options means that none get left behind.