### PR TITLE
Fix undefined fields throwing errors

### DIFF
--- a/lib/middleware/check-progress.js
+++ b/lib/middleware/check-progress.js
@@ -15,7 +15,7 @@ module.exports = function checkProgress(route, controller, steps, start) {
     var prereqs = (controller.options.prereqs || []).concat(previousSteps);
 
     var invalidatingFields = _.pick(controller.options.fields, function (f) {
-        return f.invalidates && f.invalidates.length;
+        return f && f.invalidates && f.invalidates.length;
     });
 
     var getLaterSteps = function (path) {

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -31,7 +31,7 @@ var Wizard = function (steps, fields, settings) {
 
         options = _.clone(options);
 
-        options.fields = _.object(options.fields, _.map(options.fields, function(f) { return fields[f]; }));
+        options.fields = _.object(options.fields, _.map(options.fields, function(f) { return fields[f] || {}; }));
         options.steps = steps;
 
         // default template is the same as the pathname

--- a/test/middleware/spec.check-progress.js
+++ b/test/middleware/spec.check-progress.js
@@ -1,0 +1,30 @@
+var checkSession = require('../../lib/middleware/check-progress'),
+    Model = require('../../lib/model');
+
+describe('middleware/check-session', function () {
+
+    var req, res, next, controller;
+
+    beforeEach(function () {
+        req = request();
+        req.sessionModel = new Model({}, { session: req.session, key: 'test' });
+        res = response();
+        next = sinon.stub();
+        controller = {
+            on: function () {},
+            options: {
+                fields: {
+                    field1: {},
+                    field2: undefined
+                }
+            }
+        };
+    });
+
+    it('does not throw if some fields are undefined', function () {
+        var middleware = checkSession('/route', controller, {}, '/first');
+        middleware(req, res, next);
+        next.should.have.been.calledWithExactly();
+    });
+
+});

--- a/test/spec.wizard.js
+++ b/test/spec.wizard.js
@@ -59,7 +59,7 @@ describe('Form Wizard', function () {
 
             constructor.args[0][0].fields.should.eql({
                 field1: { validate: 'required' },
-                field2: undefined
+                field2: {}
             });
 
         });


### PR DESCRIPTION
Checking a field for invalidation throws an error if the field is undefined. Protect against this, and also default undefined fields