### PR TITLE
Restrict errors returned from getErrors to only fields on the current step

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -21,7 +21,7 @@ Controller.prototype.saveValues = function (req, res, callback) {
 };
 
 Controller.prototype.getErrors = function(req, res) {
-    return req.sessionModel.get('errors');
+    return _.pick(req.sessionModel.get('errors'), Object.keys(this.options.fields));
 };
 
 Controller.prototype.setErrors = function(err, req, res) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "chai": "^2.1.2",
     "mocha": "^2.2.1",
-    "reqres": "^1.1.1",
+    "reqres": "^1.1.3",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0"
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,12 +1,11 @@
-var chai = require('chai'),
-    reqres = require('reqres');
+var chai = require('chai');
 
 global.should = chai.should();
 global.expect = chai.expect;
 global.sinon = require('sinon');
 
 global.StubController = require('./helpers/controller');
-global.request = reqres.req;
-global.response = reqres.res;
+global.request = require('./helpers/request');
+global.response = require('./helpers/response');
 
 chai.use(require('sinon-chai'));

--- a/test/helpers/request.js
+++ b/test/helpers/request.js
@@ -1,11 +1,9 @@
-var _ = require('underscore');
+var _ = require('underscore'),
+    reqres = require('reqres'),
+    SessionModel = require('../../lib/model');
 
 module.exports = function (settings) {
-    var defaults = {
-        method: 'GET',
-        url: '/',
-        session: {},
-        cookies: {}
-    };
-    return _.extend({}, defaults, settings);
+    var req = reqres.req(settings);
+    req.sessionModel = req.sessionModel || new SessionModel({}, { session: req.session, key: 'test' });
+    return req;
 };

--- a/test/helpers/response.js
+++ b/test/helpers/response.js
@@ -1,10 +1,1 @@
-var _ = require('underscore'),
-    sinon = require('sinon');
-
-module.exports = function (settings) {
-    var defaults = {
-        locals: sinon.stub(),
-        cookie: sinon.stub()
-    };
-    return _.extend({}, defaults, settings);
-};
+module.exports = require('reqres').res;

--- a/test/spec.controller.js
+++ b/test/spec.controller.js
@@ -1,0 +1,33 @@
+var Controller = require('../lib/controller');
+
+describe('Form Controller', function () {
+
+    var controller, req, res;
+
+    describe('getErrors', function () {
+
+        beforeEach(function () {
+            req = request();
+            res = {};
+            controller = new Controller({
+                template: 'index',
+                fields: {
+                    field1: {},
+                    field2: {}
+                }
+            });
+
+        });
+
+        it('only returns errors from fields relevant to the current step', function () {
+            req.sessionModel.set('errors', {
+                field1: 'foo',
+                field3: 'bar'
+            });
+            var errors = controller.getErrors(req, res);
+            errors.should.eql({ field1: 'foo' });
+        });
+
+    });
+
+});


### PR DESCRIPTION
Fixes #5 - clicking back from a step with validation errors causes the errors to be erroneously shown on the previous step. Whitelist the errors which can be shown on a step to only those which are related to the step's own fields.