### PR TITLE
Handle additional url parameters

### DIFF
--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -10,6 +10,7 @@ var Wizard = function (steps, fields, settings) {
 
     settings = _.extend({
         templatePath: 'pages',
+        params: '',
         controller: Form
     }, settings || {});
 
@@ -49,7 +50,7 @@ var Wizard = function (steps, fields, settings) {
             controller.Error.prototype.translate = settings.translate;
         }
 
-        app.route(route)
+        app.route(route + settings.params)
             .all([
                 require('./middleware/session-model')(settings),
                 require('./middleware/check-session')(route, controller, steps, first),

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "depd": "^1.0.0",
     "express": "^4.12.2",
     "express-session": "^1.10.3",
-    "hmpo-form-controller": "^0.1.0",
+    "hmpo-form-controller": "^0.1.1",
     "hmpo-model": "0.0.0",
     "hogan.js": "^3.0.2",
     "i18n-lookup": "^0.1.0",

--- a/test/spec.wizard.js
+++ b/test/spec.wizard.js
@@ -66,4 +66,51 @@ describe('Form Wizard', function () {
 
     });
 
+    describe('router params', function () {
+
+        beforeEach(function () {
+            res = response();
+            next = sinon.stub();
+        });
+
+        it('binds additional params onto route', function (done) {
+            req = request({
+                url: '/step/edit'
+            });
+            requestHandler = function (req, res, next) {
+                req.params.action.should.equal('edit');
+                next();
+            };
+            wizard = Wizard({
+                '/step': {
+                    controller: StubController({ requestHandler: requestHandler })
+                }
+            }, {}, { name: 'test-wizard', params: '/:action?' });
+            wizard(req, res, function (err) {
+                expect(err).not.to.be.ok;
+                done(err);
+            });
+        });
+
+        it('handles parameterless routes', function (done) {
+            req = request({
+                url: '/step'
+            });
+            requestHandler = function (req, res, next) {
+                expect(req.params.action).to.be.undefined;
+                next();
+            };
+            wizard = Wizard({
+                '/step': {
+                    controller: StubController({ requestHandler: requestHandler })
+                }
+            }, {}, { name: 'test-wizard', params: '/:action?' });
+            wizard(req, res, function (err) {
+                expect(err).not.to.be.ok;
+                done(err);
+            });
+        });
+
+    });
+
 });


### PR DESCRIPTION
Allow implementations to configure if they wish any additional url parameters to be available. For example, the renewal journey needs to be able to append '/edit' onto urls in order to support the edit journey.