### PR TITLE
Throw Error on session timeout

### DIFF
--- a/lib/middleware/check-session.js
+++ b/lib/middleware/check-session.js
@@ -2,7 +2,9 @@ module.exports = function (route, controller, steps, first) {
     return function checkSession(req, res, next) {
         if (controller.options.checkSession !== false && (req.method === 'POST' || req.path !== first)) {
             if (req.cookies['pex-sc'] && req.session.exists !== true) {
-                return next({ code: 'SESSION_TIMEOUT' });
+                var err = new Error('Session expired');
+                err.code = 'SESSION_TIMEOUT';
+                return next(err);
             }
         }
         req.session.exists = true;

--- a/test/middleware/spec.check-session.js
+++ b/test/middleware/spec.check-session.js
@@ -19,10 +19,27 @@ describe('middleware/check-session', function () {
         next = sinon.stub();
     });
 
+    it('throws session error if cookie exists, but session flag does not', function () {
+        var middleware = checkSession('/route', { options: {} }, {}, '/first');
+        middleware(req, res, function (err) {
+            err.should.be.an.instanceOf(Error);
+            err.code.should.equal('SESSION_TIMEOUT')
+        });
+    });
+
+    it('does not throw error on GET to first route', function () {
+        var middleware = checkSession('/route', { options: {} }, {}, '/first');
+        req.path = '/first';
+        middleware(req, res, function (err) {
+            expect(err).to.be.undefined;
+        });
+    });
+
     it('does not throw session error if controller checkSession option is false', function () {
         var middleware = checkSession('/route', { options: { checkSession: false } }, {}, '/first');
-        middleware(req, res, next);
-        next.should.have.been.calledWithExactly();
+        middleware(req, res, function (err) {
+            expect(err).to.be.undefined;
+        });
     });
 
 });


### PR DESCRIPTION
By throwing actual Error instances we get improved debugging and semantics such as stack traces. Logging is also made more consistent.

This is part of a larger set of opinions that we should try and be a little more type-strict and throw actual error objects when throwing errors.