### PR TITLE
Do not return errors which redirect to exit pages from getErrors

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -21,7 +21,12 @@ Controller.prototype.saveValues = function (req, res, callback) {
 };
 
 Controller.prototype.getErrors = function(req, res) {
-    return _.pick(req.sessionModel.get('errors'), Object.keys(this.options.fields));
+    var errs = req.sessionModel.get('errors');
+    errs = _.pick(errs, Object.keys(this.options.fields));
+    errs = _.pick(errs, function (err, key) {
+        return !err.redirect;
+    });
+    return errs;
 };
 
 Controller.prototype.setErrors = function(err, req, res) {

--- a/test/spec.controller.js
+++ b/test/spec.controller.js
@@ -45,6 +45,19 @@ describe('Form Controller', function () {
             errors.should.eql({ field1: 'foo' });
         });
 
+        it('does not return errors with a redirect property', function () {
+           req.sessionModel.set('errors', {
+                field1: {
+                    redirect: '/exit-page'
+                },
+                field2: {
+                    message: 'message'
+                }
+            });
+            var errors = controller.getErrors(req, res);
+            errors.should.eql({ field2: { message: 'message' } }); 
+        });
+
     });
 
 });


### PR DESCRIPTION
Fixes a bug where clicking back from an exit page will display an inline error where it is not required.