### PR TITLE
Support for absolutely defined back links

### DIFF
--- a/lib/middleware/back-links.js
+++ b/lib/middleware/back-links.js
@@ -1,4 +1,5 @@
 var url = require('url'),
+    path = require('path'),
     _ = require('underscore');
 
 module.exports = function backLink(route, controller, steps) {
@@ -12,11 +13,12 @@ module.exports = function backLink(route, controller, steps) {
 
     var checkReferrer = function (referrer, baseUrl) {
         var referrerPath = url.parse(referrer).path;
-        if (baseUrl !== '/') {
-            referrerPath = referrerPath.replace(baseUrl, '');
-        }
-        if (controller.options.backLinks.indexOf(referrerPath) > -1) {
-            return referrerPath;
+        referrerPath = path.relative(baseUrl, referrerPath);
+        var matchingPath = _.find(controller.options.backLinks, function (link) {
+            return path.normalize(link) === referrerPath;
+        });
+        if (typeof matchingPath === 'string') {
+            return path.normalize(matchingPath);
         }
     };
 
@@ -27,7 +29,7 @@ module.exports = function backLink(route, controller, steps) {
         if (typeof controller.options.backLink !== 'undefined') {
             return controller.options.backLink;
         } else if (previous.length) {
-            backLink = _.last(previous);
+            backLink = _.last(previous).replace(/^\//, '');
         } else if (controller.options.backLinks && req.get('referrer')) {
             backLink = checkReferrer(req.get('referrer'), req.baseUrl);
         }

--- a/lib/middleware/back-links.js
+++ b/lib/middleware/back-links.js
@@ -14,7 +14,7 @@ module.exports = function backLink(route, controller, steps) {
     var checkReferrer = function (referrer, baseUrl) {
         var referrerPath = url.parse(referrer).path;
         var matchingPath = _.find(controller.options.backLinks, function (link) {
-            if (path.isAbsolute(link)) {
+            if (link.match(/^\//)) {
                 return path.normalize(link) === referrerPath;
             } else {
                 return path.normalize(link) === path.relative(baseUrl, referrerPath);

--- a/lib/middleware/back-links.js
+++ b/lib/middleware/back-links.js
@@ -13,9 +13,12 @@ module.exports = function backLink(route, controller, steps) {
 
     var checkReferrer = function (referrer, baseUrl) {
         var referrerPath = url.parse(referrer).path;
-        referrerPath = path.relative(baseUrl, referrerPath);
         var matchingPath = _.find(controller.options.backLinks, function (link) {
-            return path.normalize(link) === referrerPath;
+            if (path.isAbsolute(link)) {
+                return path.normalize(link) === referrerPath;
+            } else {
+                return path.normalize(link) === path.relative(baseUrl, referrerPath);
+            }
         });
         if (typeof matchingPath === 'string') {
             return path.normalize(matchingPath);

--- a/test/middleware/spec.back-link.js
+++ b/test/middleware/spec.back-link.js
@@ -131,6 +131,16 @@ describe('Back Links', function () {
         res.locals.backLink.should.equal('whitelist');
     });
 
+    it('supports absolute paths in whitelist', function () {
+        req.get.withArgs('referrer').returns('http://example.com/whitelist');
+        req.sessionModel.set('steps', ['/step1', '/step2']);
+        req.baseUrl = '/base';
+        steps['/step2'].next = null;
+        controller.options.backLinks = ['/whitelist'];
+        backLinks('/step3', controller, steps)(req, res, next);
+        res.locals.backLink.should.equal('/whitelist');
+    });
+
     it('returns undefined if referrer header is not on whitelist', function () {
         req.get.withArgs('referrer').returns('http://example.com/not-whitelisted');
         req.sessionModel.set('steps', ['/step1', '/step2']);

--- a/test/middleware/spec.back-link.js
+++ b/test/middleware/spec.back-link.js
@@ -73,7 +73,7 @@ describe('Back Links', function () {
     it('adds the previous step to res.locals.backLink', function () {
         req.sessionModel.set('steps', ['/step1']);
         backLinks('/step2', controller, steps)(req, res, next);
-        res.locals.backLink.should.equal('/step1');
+        res.locals.backLink.should.equal('step1');
     });
 
     it('is not defined for first step of journey', function () {
@@ -84,11 +84,11 @@ describe('Back Links', function () {
     it('adds the most recently visited previous step if there are multiple options', function () {
         req.sessionModel.set('steps', ['/step1', '/step3', '/step3a']);
         backLinks('/step4', controller, steps)(req, res, next);
-        res.locals.backLink.should.equal('/step3a');
+        res.locals.backLink.should.equal('step3a');
 
         req.sessionModel.set('steps', ['/step1', '/step3a', '/step3']);
         backLinks('/step4', controller, steps)(req, res, next);
-        res.locals.backLink.should.equal('/step3');
+        res.locals.backLink.should.equal('step3');
     });
 
     it('uses configured backLink property if it exists', function () {
@@ -104,29 +104,38 @@ describe('Back Links', function () {
     });
 
     it('whitelists referrer header if no configured backwards route', function () {
-        req.get.withArgs('referrer').returns('/whitelist');
+        req.get.withArgs('referrer').returns('http://example.com/whitelist');
         req.sessionModel.set('steps', ['/step1', '/step2']);
         steps['/step2'].next = null;
-        controller.options.backLinks = ['/whitelist'];
+        controller.options.backLinks = ['whitelist'];
         backLinks('/step3', controller, steps)(req, res, next);
-        res.locals.backLink.should.equal('/whitelist');
+        res.locals.backLink.should.equal('whitelist');
+    });
+
+    it('supports links prefixed with `./`', function () {
+        req.get.withArgs('referrer').returns('http://example.com/whitelist');
+        req.sessionModel.set('steps', ['/step1', '/step2']);
+        steps['/step2'].next = null;
+        controller.options.backLinks = ['./whitelist'];
+        backLinks('/step3', controller, steps)(req, res, next);
+        res.locals.backLink.should.equal('whitelist');
     });
 
     it('strips baseUrl before checking whitelist', function () {
-        req.get.withArgs('referrer').returns('/base/whitelist');
+        req.get.withArgs('referrer').returns('http://example.com/base/whitelist');
         req.sessionModel.set('steps', ['/step1', '/step2']);
         req.baseUrl = '/base';
         steps['/step2'].next = null;
-        controller.options.backLinks = ['/whitelist'];
+        controller.options.backLinks = ['whitelist'];
         backLinks('/step3', controller, steps)(req, res, next);
-        res.locals.backLink.should.equal('/whitelist');
+        res.locals.backLink.should.equal('whitelist');
     });
 
     it('returns undefined if referrer header is not on whitelist', function () {
-        req.get.withArgs('referrer').returns('/not-whitelisted');
+        req.get.withArgs('referrer').returns('http://example.com/not-whitelisted');
         req.sessionModel.set('steps', ['/step1', '/step2']);
         steps['/step2'].next = null;
-        controller.options.backLinks = ['/whitelist'];
+        controller.options.backLinks = ['whitelist'];
         backLinks('/', controller, steps)(req, res, next);
         expect(res.locals.backLink).to.be.undefined;
     });


### PR DESCRIPTION
At the moment all back links are created relative to the baseUrl, with string concatenation. 

This fails at the point where we move between one service and another, and so the back links needs to be able to be configured to an absolute path which is not prefixed with the current baseUrl.

Note: this will be a major version update as it is a breaking change.