### PR TITLE
Prefix session namespace

### DIFF
--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -16,9 +16,11 @@ var Wizard = function (steps, fields, settings) {
 
     // prevent potentially conflicting session namespaces
     if (!settings.name) {
-        settings.name = 'hmpo-wizard-' + count;
+        settings.name = count;
         count++;
     }
+
+    settings.name = 'hmpo-wizard-' + settings.name;
 
     var app = express.Router();
 

--- a/test/spec.wizard.js
+++ b/test/spec.wizard.js
@@ -17,12 +17,12 @@ describe('Form Wizard', function () {
                 '/': {
                     controller: StubController({ requestHandler: requestHandler })
                 }
-            }, {}, { name: 'test-wizard', csrf: false });
+            }, {}, { name: 'test', csrf: false });
         });
 
         it('creates a namespace on the session', function (done) {
             wizard(req, res, function (err) {
-                req.session['test-wizard'].should.eql({});
+                req.session['hmpo-wizard-test'].should.eql({});
                 done(err);
             });
         });
@@ -35,7 +35,7 @@ describe('Form Wizard', function () {
         });
 
         it('initialises model with data from session', function (done) {
-            req.session['test-wizard'] = {
+            req.session['hmpo-wizard-test'] = {
                 name: 'John'
             };
             wizard(req, res, function (err) {


### PR DESCRIPTION
To prevent potential collisions with apps which also do direct session access add a prefix to the namespaces we create.