### PR TITLE
Shift responsibility for handling missing pre-requisites from middleware to controller

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -1,5 +1,6 @@
 var util = require('util'),
     _ = require('underscore'),
+    path = require('path'),
     Form = require('hmpo-form-controller');
 
 function Controller() {
@@ -41,6 +42,24 @@ Controller.prototype.locals = function (req, res) {
         baseUrl: req.baseUrl,
         nextPage: this.getNextStep(req, res)
     };
+};
+
+Controller.prototype.missingPrereqHandler = function (req, res, next) {
+    var last = _.last(req.sessionModel.get('steps')),
+        redirect = _.first(Object.keys(this.options.steps));
+
+    if (last && this.options.steps[last]) {
+        redirect = this.options.steps[last].next || last;
+    }
+    res.redirect(path.join(req.baseUrl, redirect));
+};
+
+Controller.prototype.errorHandler = function (err, req, res, next) {
+    if (err.code === 'MISSING_PREREQ') {
+        this.missingPrereqHandler(req, res, next);
+    } else {
+        Form.prototype.errorHandler.call(this, err, req, res, next);
+    }
 };
 
 Controller.Error = Form.Error;

--- a/lib/middleware/check-progress.js
+++ b/lib/middleware/check-progress.js
@@ -44,16 +44,6 @@ module.exports = function checkProgress(route, controller, steps, start) {
         req.sessionModel.set('steps', sessionsteps);
     });
 
-    controller.on('prerequisite-error', function (req, res) {
-        var last = _.last(req.sessionModel.get('steps')),
-            redirect = start;
-
-        if (last && steps[last]) {
-            redirect = steps[last].next || last;
-        }
-        res.redirect(req.baseUrl + redirect);
-    });
-
     return function (req, res, next) {
 
         _.each(invalidatingFields, function (field, key) {
@@ -73,7 +63,9 @@ module.exports = function checkProgress(route, controller, steps, start) {
         if (visited.length || !prereqs.length) {
             next();
         } else {
-            controller.emit('prerequisite-error', req, res);
+            var err = new Error('Missing prerequisite');
+            err.code = 'MISSING_PREREQ';
+            next(err);
         }
     };
 

--- a/test/middleware/spec.check-progress.js
+++ b/test/middleware/spec.check-progress.js
@@ -1,30 +1,41 @@
 var checkSession = require('../../lib/middleware/check-progress'),
-    Model = require('../../lib/model');
+    Model = require('../../lib/model'),
+    Controller = require('../../lib/controller');
 
 describe('middleware/check-session', function () {
 
-    var req, res, next, controller;
+    var req, res, next, controller, steps;
 
     beforeEach(function () {
         req = request();
         req.sessionModel = new Model({}, { session: req.session, key: 'test' });
         res = response();
         next = sinon.stub();
-        controller = {
-            on: function () {},
-            options: {
-                fields: {
-                    field1: {},
-                    field2: undefined
-                }
-            }
-        };
+        controller = new Controller({ template: 'index' });
+        steps = {
+            '/one': { next: '/two' },
+            '/two': { next: '/three' },
+            '/three': { next: '/four' },
+            '/four': {}
+        }
     });
 
-    it('does not throw if some fields are undefined', function () {
-        var middleware = checkSession('/route', controller, {}, '/first');
-        middleware(req, res, next);
-        next.should.have.been.calledWithExactly();
+    it('calls callback with no arguments if prerequisite steps are complete', function (done) {
+        req.sessionModel.set('steps', [ '/one', '/two' ]);
+        var middleware = checkSession('/three', controller, steps, '/one');
+        middleware(req, res, function (err) {
+            expect(err).to.be.undefined;
+            done();
+        });
+    });
+
+    it('calls callback with MISSING_PREREQ error code if accessing step that has not had prerequisite steps complete', function (done) {
+        req.sessionModel.set('steps', []);
+        var middleware = checkSession('/three', controller, steps, '/one');
+        middleware(req, res, function (err) {
+            err.code.should.equal('MISSING_PREREQ');
+            done();
+        });
     });
 
 });

--- a/test/spec.controller.js
+++ b/test/spec.controller.js
@@ -3,7 +3,20 @@ var Controller = require('../lib/controller'),
 
 describe('Form Controller', function () {
 
-    var controller, req, res;
+    var controller, req, res, next;
+
+    beforeEach(function () {
+        req = request();
+        res = response();
+        next = sinon.stub();
+        controller = new Controller({
+            template: 'index',
+            fields: {
+                field1: {},
+                field2: {}
+            }
+        });
+    });
 
     describe('validators', function () {
 
@@ -22,19 +35,6 @@ describe('Form Controller', function () {
     });
 
     describe('getErrors', function () {
-
-        beforeEach(function () {
-            req = request();
-            res = {};
-            controller = new Controller({
-                template: 'index',
-                fields: {
-                    field1: {},
-                    field2: {}
-                }
-            });
-
-        });
 
         it('only returns errors from fields relevant to the current step', function () {
             req.sessionModel.set('errors', {
@@ -55,7 +55,60 @@ describe('Form Controller', function () {
                 }
             });
             var errors = controller.getErrors(req, res);
-            errors.should.eql({ field2: { message: 'message' } }); 
+            errors.should.eql({ field2: { message: 'message' } });
+        });
+
+    });
+
+    describe('errorHandler', function () {
+
+        beforeEach(function () {
+            sinon.stub(Form.prototype, 'errorHandler');
+            sinon.stub(Controller.prototype, 'missingPrereqHandler');
+        });
+
+        afterEach(function () {
+            Form.prototype.errorHandler.restore();
+            Controller.prototype.missingPrereqHandler.restore();
+        });
+
+        it('calls missingPrereqHandler for missing prerquisite errors', function () {
+            var err = new Error('foo');
+            err.code = 'MISSING_PREREQ';
+            controller.errorHandler(err, req, res, next);
+            controller.missingPrereqHandler.should.have.been.calledWithExactly(req, res, next);
+        });
+
+        it('passes through to parent errorHandler for all other errors', function () {
+            var err = new Error('foo');
+            controller.errorHandler(err, req, res, next);
+            Form.prototype.errorHandler.should.have.been.calledWithExactly(err, req, res, next);
+            Form.prototype.errorHandler.should.have.been.calledOn(controller);
+        });
+
+    });
+
+    describe('missingPrereqHandler', function () {
+
+        beforeEach(function () {
+            controller.options.steps = {
+                '/one': { next: '/two' },
+                '/two': { next: '/three' },
+                '/three': { next: '/four' },
+                '/four': {}
+            };
+        });
+
+        it('redirects to the step following the most recently completed', function () {
+            req.sessionModel.set('steps', ['/one']);
+            controller.missingPrereqHandler(req, res, next);
+            res.redirect.should.have.been.calledWith('/two');
+        });
+
+        it('redirects to the first step if no steps have been completed', function () {
+            req.sessionModel.set('steps', []);
+            controller.missingPrereqHandler(req, res, next);
+            res.redirect.should.have.been.calledWith('/one');
         });
 
     });


### PR DESCRIPTION
Handling missing pre-requisites at the middleware level prevents custom behaviour from being bound. Instead shift the handling for missing pre-requisites into the controller so that implementations can extend the methods to create their own custom handling.