### PR TITLE
Ensure middleware that can report errors are bound to the controller

### DIFF
--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -52,19 +52,20 @@ var Wizard = function (steps, fields, settings) {
             controller.Error.prototype.translate = settings.translate;
         }
 
-        var stack = [
-            require('./middleware/session-model')(settings),
+        controller.use([
             require('./middleware/check-session')(route, controller, steps, first),
-            require('./middleware/back-links')(route, controller, steps, first),
             require('./middleware/check-progress')(route, controller, steps, first)
-        ];
+        ]);
         if (settings.csrf !== false) {
-            stack.push(require('./middleware/csrf')(route, controller, steps, first));
+            controller.use(require('./middleware/csrf')(route, controller, steps, first));
         }
-        stack.push(controller.requestHandler());
+
 
         app.route(route + settings.params)
-            .all(stack);
+            .all(require('./middleware/session-model')(settings))
+            .all(require('./middleware/back-links')(route, controller, steps, first))
+            .all(controller.requestHandler());
+
 
     });
 

--- a/test/helpers/controller.js
+++ b/test/helpers/controller.js
@@ -18,6 +18,8 @@ module.exports = function (options) {
         return options.requestHandler;
     };
 
+    Controller.prototype.use = sinon.stub();
+
     return Controller;
 
 };


### PR DESCRIPTION
Middlewares which are not bound to the controller will not pass through controller level error handling. To resolve this, bind the check session, progress, and csrf middlewares onto the controller using controller.use instead of onto the parent router. This means that controllers can attach their own custom error handling for the errors that these middlewares emit, instead of having them bound at a router level where errors can only be resolved at an application level.

This fixes a bug in the previous release where error handling was put into controllers for pre-requisite step errors, but is never actually hit because the error is not thrown in the controller level router.