### PR TITLE
Update error classes to support request level translate methods

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -21,7 +21,11 @@ function compile(t, context) {
     return require('hogan.js').compile(t).render(context);
 }
 
-function FormError() {
+function FormError(key, options, req) {
+    req = req || {};
+    if (typeof req.translate === 'function') {
+        this.translate = req.translate;
+    }
     Controller.Error.apply(this, arguments);
 }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "depd": "^1.0.0",
     "express": "^4.12.2",
     "express-session": "^1.10.3",
-    "hmpo-form-controller": "^0.3.0",
+    "hmpo-form-controller": "^0.4.0",
     "hmpo-model": "0.0.0",
     "hogan.js": "^3.0.2",
     "i18n-lookup": "^0.1.0",

--- a/test/spec.error.js
+++ b/test/spec.error.js
@@ -1,0 +1,80 @@
+var ErrorClass = require('../lib/error');
+
+describe('Error', function () {
+
+    var req;
+
+    beforeEach(function () {
+        req = request({
+            translate: sinon.stub().returnsArg(0)
+        });
+    });
+
+    describe('getMessage', function () {
+
+        it('uses the translate method from the initialising request to translate the message', function () {
+            req.translate.withArgs('validation.key.required').returns('This field is required');
+            var error = new ErrorClass('key', { type: 'required' }, req);
+            error.message.should.equal('This field is required');
+        });
+
+        it('uses default error message for field if no field and type specific message is defined', function () {
+            req.translate.withArgs('validation.key.default').returns('Default field message');
+            var error = new ErrorClass('key', { type: 'required' }, req);
+            error.message.should.equal('Default field message');
+        });
+
+        it('uses default error message for validation type if no field level message is defined', function () {
+            req.translate.withArgs('validation.required').returns('Default required message');
+            var error = new ErrorClass('key', { type: 'required' }, req);
+            error.message.should.equal('Default required message');
+        });
+
+        it('uses global default error message if no type of field level messages are defined', function () {
+            req.translate.withArgs('validation.default').returns('Global default');
+            var error = new ErrorClass('key', { type: 'required' }, req);
+            error.message.should.equal('Global default');
+        });
+
+        it('populates messages with field label', function () {
+            req.translate.withArgs('validation.key.required').returns('Your {{label}} is required');
+            req.translate.withArgs('fields.key.label').returns('Field label');
+            var error = new ErrorClass('key', { type: 'required' }, req);
+            error.message.should.equal('Your field label is required');
+        });
+
+        it('populates maxlength messages with the maximum length', function () {
+            req.translate.withArgs('validation.key.maxlength').returns('This must be less than {{maxlength}} characters');
+            var error = new ErrorClass('key', { type: 'maxlength', arguments: [10] }, req);
+            error.message.should.equal('This must be less than 10 characters');
+        });
+
+        it('populates minlength messages with the minimum length', function () {
+            req.translate.withArgs('validation.key.minlength').returns('This must be no more than {{minlength}} characters');
+            var error = new ErrorClass('key', { type: 'minlength', arguments: [10] }, req);
+            error.message.should.equal('This must be no more than 10 characters');
+        });
+
+        it('populates exactlength messages with the required length', function () {
+            req.translate.withArgs('validation.key.exactlength').returns('This must be {{exactlength}} characters');
+            var error = new ErrorClass('key', { type: 'exactlength', arguments: [10] }, req);
+            error.message.should.equal('This must be 10 characters');
+        });
+
+        it('populates past messages with the required difference', function () {
+            req.translate.withArgs('validation.key.past').returns('This must be less than {{age}} ago');
+            var error = new ErrorClass('key', { type: 'past', arguments: [5, 'days'] }, req);
+            error.message.should.equal('This must be less than 5 days ago');
+        });
+
+        it('uses own translate method if no req.translate is defined', function () {
+            delete req.translate;
+            sinon.stub(ErrorClass.prototype, 'translate').returns('Custom translate');
+            var error = new ErrorClass('key', { type: 'required' }, req);
+            error.message.should.equal('Custom translate');
+            ErrorClass.prototype.translate.restore();
+        });
+
+    });
+
+});


### PR DESCRIPTION
Proper i18n methods will change the language based on parameters on the request, so will need to take this into account when translating error messages

Use the translation method from the request if it exists when translating error messaging.