### PR TITLE
Set controller error class in the constructor

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -1,10 +1,12 @@
 var util = require('util'),
     _ = require('underscore'),
     path = require('path'),
+    ErrorClass = require('./error'),
     Form = require('hmpo-form-controller');
 
 function Controller() {
     Form.apply(this, arguments);
+    this.Error = ErrorClass;
 }
 
 util.inherits(Controller, Form);
@@ -62,7 +64,7 @@ Controller.prototype.errorHandler = function (err, req, res, next) {
     }
 };
 
-Controller.Error = Form.Error;
+Controller.Error = ErrorClass;
 Controller.validators = Form.validators;
 Controller.formatters = Form.formatters;
 

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -1,8 +1,7 @@
 var express = require('express'),
     util = require('util'),
     _ = require('underscore'),
-    Form = require('./controller'),
-    ErrorClass = require('./error');
+    Form = require('./controller');
 
 var count = 0;
 
@@ -44,10 +43,6 @@ var Wizard = function (steps, fields, settings) {
         var Controller = options.controller || settings.controller;
 
         var controller = new Controller(options);
-        controller.Error = function () {
-            ErrorClass.apply(this, arguments);
-        };
-        util.inherits(controller.Error, ErrorClass);
         if (settings.translate) {
             controller.Error.prototype.translate = settings.translate;
         }
@@ -74,6 +69,6 @@ var Wizard = function (steps, fields, settings) {
 };
 
 Wizard.Controller = Form;
-Wizard.Error = ErrorClass;
+Wizard.Error = Form.Error;
 
 module.exports = Wizard;

--- a/test/spec.controller.js
+++ b/test/spec.controller.js
@@ -1,4 +1,5 @@
 var Controller = require('../lib/controller'),
+    ErrorClass = require('../lib/error'),
     Form = require('hmpo-form-controller');
 
 describe('Form Controller', function () {
@@ -30,6 +31,15 @@ describe('Form Controller', function () {
 
         it('exposes formatters', function () {
             Controller.formatters.should.eql(Form.formatters);
+        });
+
+    });
+
+    describe('Error', function () {
+
+        it('is an instance of Wizard.Error', function () {
+            var err = new controller.Error('key', { type: 'required' });
+            err.should.be.an.instanceOf(ErrorClass);
         });
 
     });


### PR DESCRIPTION
At the moment the error class is only set as part of the wizard constructor, which means that controllers will only have their error class set when in the context of a wizard, and not when constructed standalone. This means that testing error handling and generation cannot be done whilst encapsulating the controller.

Setting the error class on a controller at construction time rather than in the wizard post-construction allows the behaviour to be inherited in standalone controllers.