### PR TITLE
Don't remove slash from backlinks.

### DIFF
--- a/lib/middleware/back-links.js
+++ b/lib/middleware/back-links.js
@@ -32,7 +32,8 @@ module.exports = function backLink(route, controller, steps) {
         if (typeof controller.options.backLink !== 'undefined') {
             return controller.options.backLink;
         } else if (previous.length) {
-            backLink = _.last(previous).replace(/^\//, '');
+            backLink = _.last(previous);
+            backLink = (backLink === '/') ? '' : backLink;
         } else if (controller.options.backLinks && req.get('referrer')) {
             backLink = checkReferrer(req.get('referrer'), req.baseUrl);
         }

--- a/test/middleware/spec.back-link.js
+++ b/test/middleware/spec.back-link.js
@@ -73,7 +73,7 @@ describe('Back Links', function () {
     it('adds the previous step to res.locals.backLink', function () {
         req.sessionModel.set('steps', ['/step1']);
         backLinks('/step2', controller, steps)(req, res, next);
-        res.locals.backLink.should.equal('step1');
+        res.locals.backLink.should.equal('/step1');
     });
 
     it('is not defined for first step of journey', function () {
@@ -84,11 +84,23 @@ describe('Back Links', function () {
     it('adds the most recently visited previous step if there are multiple options', function () {
         req.sessionModel.set('steps', ['/step1', '/step3', '/step3a']);
         backLinks('/step4', controller, steps)(req, res, next);
-        res.locals.backLink.should.equal('step3a');
+        res.locals.backLink.should.equal('/step3a');
 
         req.sessionModel.set('steps', ['/step1', '/step3a', '/step3']);
         backLinks('/step4', controller, steps)(req, res, next);
-        res.locals.backLink.should.equal('step3');
+        res.locals.backLink.should.equal('/step3');
+    });
+
+    it('removes the slash if the backlink is only a slash', function () {
+        var slashSteps = {
+            '/': {
+                next: '/step1'
+            },
+            '/step1': {}
+        };
+        req.sessionModel.set('steps', ['/']);
+        backLinks('/step1', controller, slashSteps)(req, res, next);
+        res.locals.backLink.should.equal('');
     });
 
     it('uses configured backLink property if it exists', function () {


### PR DESCRIPTION
I have no idea why the code removes the backlinks if the backlink is just relying on the last step.

It introduces bugs for us. All other tests expect the backlinks to have slashes so I can't figure out why.

This PR re-introduces slashes for backlinks that are just checked from the session steps.

The one usecase I can see where backlinks would need to remove the slash is where the last step in the flow was just '/'

In that case this PR checks for the existance for a single referring '/' and sets it to '' which will disable the backlink.