### PR TITLE
Support for multiple translators

### DIFF
--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -43,9 +43,6 @@ var Wizard = function (steps, fields, settings) {
         var Controller = options.controller || settings.controller;
 
         var controller = new Controller(options);
-        if (settings.translate) {
-            controller.Error.prototype.translate = settings.translate;
-        }
 
         controller.use([
             require('./middleware/check-session')(route, controller, steps, first),
@@ -55,8 +52,13 @@ var Wizard = function (steps, fields, settings) {
             controller.use(require('./middleware/csrf')(route, controller, steps, first));
         }
 
-
         app.route(route + settings.params)
+            .all(function (req, res, next) {
+                if (settings.translate) {
+                    req.translate = settings.translate;
+                }
+                next();
+            })
             .all(require('./middleware/session-model')(settings))
             .all(require('./middleware/back-links')(route, controller, steps, first))
             .all(controller.requestHandler());

--- a/test/spec.wizard.js
+++ b/test/spec.wizard.js
@@ -162,6 +162,34 @@ describe('Form Wizard', function () {
 
         });
 
+
+    });
+
+    describe('app middlewares', function () {
+        beforeEach(function () {
+            req = request();
+            res = response();
+            next = sinon.stub();
+            requestHandler = sinon.stub().yields();
+            wizard = Wizard({
+                '/': {
+                    controller: StubController({ requestHandler: requestHandler })
+                }
+            }, {}, { name: 'test', csrf: false, translate: 'i18ntranslator' });
+        });
+
+        describe('applying a translate', function () {
+
+            it('sets translate to the req when defined in settings', function (done) {
+                should.equal(req.translate, undefined);
+                wizard(req, res, function (err) {
+                    req.translate.should.equal('i18ntranslator');
+                    done(err);
+                });
+
+            });
+
+        });
     });
 
 });


### PR DESCRIPTION
We've been working on reorganising apps and we'd like to be able to assign a translate per sub app

This fix stops the Error prototype getting overwritten and applys it in req.translate

This is already supported in error.js

Added tests to support the use case