### PR TITLE
Don't initialise the session unless you need to.

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -1,15 +1,16 @@
 var deprecate = require('depd')('hmpo-form-wizard');
 
 var WARNING = 'session is undefined. Falling back to express-session - not supported for production use.';
-var session = require('express-session')({
-    secret: 'secret',
-    resave: true,
-    saveUninitialized: true
-});
+var Session = require('express-session');
 
 module.exports = function (req, res, next) {
     if (typeof req.session === 'undefined') {
         deprecate(WARNING);
+        var session = new Session({
+            secret: 'secret',
+            resave: true,
+            saveUninitialized: true
+        });
         require('cookie-parser')()(req, res, function () {
             session(req, res, next);
         });


### PR DESCRIPTION
If you run in production mode ```NODE_ENV=production``` this will produce warnings
because it will use MemoryStore. Although the session may never be getting written to
it's a red herring and is undesirable for both logging and developers sanity.

Fixes #34 