### PR TITLE
Accept CSRF token via HTTP header

### DIFF
--- a/lib/middleware/csrf.js
+++ b/lib/middleware/csrf.js
@@ -1,4 +1,5 @@
 var csrf = require('csrf')();
+var _ = require('underscore');
 
 module.exports = function (route, controller) {
 
@@ -7,19 +8,34 @@ module.exports = function (route, controller) {
 
             var verify = function () {
                 var secret = req.sessionModel.get('csrf-secret');
+                var safeMethods = ['GET', 'HEAD', 'OPTIONS'];
+
                 if (!secret) {
                     csrf.secret(function (err, secret) {
                         if (err) { next(err); }
                         req.sessionModel.set('csrf-secret', secret);
                         verify();
                     });
-                } else if (req.method === 'GET') {
+                } else if (-1 !== _.indexOf(safeMethods, req.method)) {
+                    // The HTTP method is safe. No need to verify a
+                    // token. Instead, provide a new one for future
+                    // verification.
                     res.locals['csrf-token'] = csrf.create(secret);
                     next();
-                } else if (!csrf.verify(secret, req.body['x-csrf-token'])) {
-                    next({ code: 'CSRF_ERROR' });
                 } else {
-                    next();
+                    // The HTTP method is assumed to be unsafe so
+                    // require verification.
+
+                    // Token can be provided in either the request body
+                    // or the headers. Preference is given to the body.
+                    var token = req.body['x-csrf-token']
+                             || req.headers['x-csrf-token'];
+
+                    if (!csrf.verify(secret, token)) {
+                        next({ code: 'CSRF_ERROR' });
+                    } else {
+                        next();
+                    }
                 }
             };
 

--- a/test/middleware/spec.csrf.js
+++ b/test/middleware/spec.csrf.js
@@ -10,6 +10,30 @@ describe('CSRF protection', function () {
         middleware = csrf('/', { options: {} });
     });
 
+    it('accepts GET requests without a token', function (done) {
+        req.method = 'GET';
+        middleware(req, res, function (err) {
+            expect(err).to.be.undefined;
+            done();
+        });
+    });
+
+    it('accepts HEAD requests without a token', function (done) {
+        req.method = 'HEAD';
+        middleware(req, res, function (err) {
+            expect(err).to.be.undefined;
+            done();
+        });
+    });
+
+    it('accepts OPTIONS requests without a token', function (done) {
+        req.method = 'OPTIONS';
+        middleware(req, res, function (err) {
+            expect(err).to.be.undefined;
+            done();
+        });
+    });
+
     it('generates a token on GET requests', function (done) {
         req.method = 'GET';
         middleware(req, res, function () {
@@ -18,7 +42,7 @@ describe('CSRF protection', function () {
         });
     });
 
-    it('validates token on POST requests', function (done) {
+    it('validates token in body on POST requests', function (done) {
         req.method = 'GET';
         middleware(req, res, function () {
             var token = res.locals['csrf-token'];
@@ -31,9 +55,57 @@ describe('CSRF protection', function () {
         });
     });
 
-    it('passes error to callback if token is invalid', function (done) {
+    it('validates token in body on PUT requests', function (done) {
+        req.method = 'GET';
+        middleware(req, res, function () {
+            var token = res.locals['csrf-token'];
+            req.method = 'PUT';
+            req.body['x-csrf-token'] = token;
+            middleware(req, res, function (err) {
+                expect(err).to.be.undefined;
+                done();
+            });
+        });
+    });
+
+    it('validates token in headers on DELETE requests', function (done) {
+        req.method = 'GET';
+        middleware(req, res, function () {
+            var token = res.locals['csrf-token'];
+            req.method = 'DELETE';
+            req.headers['x-csrf-token'] = token;
+            middleware(req, res, function (err) {
+                expect(err).to.be.undefined;
+                done();
+            });
+        });
+    });
+
+    it('validates token in headers on PATCH requests', function (done) {
+        req.method = 'GET';
+        middleware(req, res, function () {
+            var token = res.locals['csrf-token'];
+            req.method = 'PATCH';
+            req.headers['x-csrf-token'] = token;
+            middleware(req, res, function (err) {
+                expect(err).to.be.undefined;
+                done();
+            });
+        });
+    });
+
+    it('passes error to callback if token in body is invalid', function (done) {
         req.method = 'POST';
         req.body['x-csrf-token'] = 'invalidtoken';
+        middleware(req, res, function (err) {
+            err.code.should.equal('CSRF_ERROR');
+            done();
+        });
+    });
+
+    it('passes error to callback if token in headers is invalid', function (done) {
+        req.method = 'POST';
+        req.headers['x-csrf-token'] = 'invalidtoken';
         middleware(req, res, function (err) {
             err.code.should.equal('CSRF_ERROR');
             done();


### PR DESCRIPTION
Adds support for accepting the CSRF token through an HTTP header,
'x-csrf-token', in addition to the body of the request (postdata). This make it
possible to support PATCH requests.

Also allows HEAD and OPTIONS requests through without a CSRF token as it
should not be required in these cases. (These are safe methods.)