### PR TITLE
Back-links: whitelist steps in journey history

### DIFF
--- a/lib/middleware/back-links.js
+++ b/lib/middleware/back-links.js
@@ -11,15 +11,21 @@ module.exports = function backLink(route, controller, steps) {
         return list;
     }, []);
 
-    var checkReferrer = function (referrer, baseUrl) {
+    var matchPath = function(baseUrl){
+        return function(findPath) {
+            return _.find(controller.options.backLinks, function (link) {
+                if (link.match(/^\//)) {
+                    return path.normalize(link) === findPath;
+                } else {
+                    return path.normalize(link) === path.relative(baseUrl, findPath);
+                }
+            });
+        }
+    };
+    
+    var checkReferrer = function (referrer, matcher) {
         var referrerPath = url.parse(referrer).path;
-        var matchingPath = _.find(controller.options.backLinks, function (link) {
-            if (link.match(/^\//)) {
-                return path.normalize(link) === referrerPath;
-            } else {
-                return path.normalize(link) === path.relative(baseUrl, referrerPath);
-            }
-        });
+        var matchingPath = matcher(referrerPath);
         if (typeof matchingPath === 'string') {
             return path.normalize(matchingPath);
         }
@@ -34,12 +40,29 @@ module.exports = function backLink(route, controller, steps) {
         } else if (previous.length) {
             backLink = _.last(previous).replace(/^\//, '');
         } else if (controller.options.backLinks && req.get('referrer')) {
-            backLink = checkReferrer(req.get('referrer'), req.baseUrl);
+            var matchPathFunc = matchPath(req.baseUrl);
+            backLink = checkReferrer(req.get('referrer'), matchPathFunc);
+
+            if (!backLink) {
+                var validBacklinks = _.reduce(req.sessionModel.get('steps'), function(memo, step){
+
+                    var matchedBacklink = matchPathFunc(step);
+
+                    if (typeof matchedBacklink === 'string') {
+                        memo.push(matchedBacklink);
+                    }
+                    return memo;
+
+                }, []);
+
+                if (validBacklinks.length){
+                    backLink = _.last(validBacklinks);
+                }
+            }
         }
 
         return backLink;
     };
-
     return function (req, res, next) {
         if (req.method === 'GET') {
             var last = _.last(req.sessionModel.get('steps'));

--- a/test/middleware/spec.back-link.js
+++ b/test/middleware/spec.back-link.js
@@ -150,6 +150,30 @@ describe('Back Links', function () {
         expect(res.locals.backLink).to.be.undefined;
     });
 
+    it('permits whitelisting of steps in history', function () {
+        req.get.withArgs('referrer').returns('http://example.com/base/step4');
+        req.sessionModel.set('steps', ['/step1', '/step2', '/step3a', '/step4']);
+        controller.options.backLinks = ['step2'];
+        backLinks('/step3a', controller, steps)(req, res, next);
+        res.locals.backLink.should.equal('step2');
+    });
+
+    it('returns most recent of whitelisted steps in history', function () {
+        req.get.withArgs('referrer').returns('http://example.com/base/step4');
+        req.sessionModel.set('steps', ['/step1', '/step2', '/step3a', '/step4']);
+        controller.options.backLinks = ['step2', 'step1'];
+        backLinks('/step3a', controller, steps)(req, res, next);
+        res.locals.backLink.should.equal('step2');
+    });
+
+    it('matches absolute whitelisted steps in history', function () {
+        req.get.withArgs('referrer').returns('http://example.com/base/step4');
+        req.sessionModel.set('steps', ['/step1', '/step2', '/step3a', '/step4']);
+        controller.options.backLinks = ['/step2'];
+        backLinks('/step3a', controller, steps)(req, res, next);
+        res.locals.backLink.should.equal('/step2');
+    });
+
     describe('isBackLink request object property', function () {
 
         it('is true when the last step matches the page path', function () {


### PR DESCRIPTION
Curry the path-matching function for re-use
Check history for matching back-links if referrer is not matched
Unit tests for whitelisting history items