### PR TITLE
Remove use of express session is no session defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ app.use(wizard(steps, fields));
 
 ## Sessions
 
-The wizard expects some kind of session to have been created in previous middleware layers. If this is not found then the wizard will create its own in-memory session using [express-session](https://github.com/expressjs/session) but this is not recommended for production use.
+The wizard expects some kind of session to have been created in previous middleware layers.
 
 For production use a database backed session store is recommended - such as [connect-redis](https://github.com/tj/connect-redis).
 

--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -1,19 +1,6 @@
-var deprecate = require('depd')('hmpo-form-wizard');
-
-var WARNING = 'session is undefined. Falling back to express-session - not supported for production use.';
-var Session = require('express-session');
-
 module.exports = function (req, res, next) {
     if (typeof req.session === 'undefined') {
-        deprecate(WARNING);
-        var session = new Session({
-            secret: 'secret',
-            resave: true,
-            saveUninitialized: true
-        });
-        require('cookie-parser')()(req, res, function () {
-            session(req, res, next);
-        });
+        throw new Error('Session is undefined');
     } else {
         next();
     }

--- a/package.json
+++ b/package.json
@@ -17,12 +17,9 @@
   },
   "homepage": "https://github.com/UKHomeOffice/passports-form-wizard",
   "dependencies": {
-    "cookie-parser": "^1.3.4",
     "csrf": "^2.0.6",
     "debug": "^2.1.2",
-    "depd": "^1.0.0",
     "express": "^4.12.2",
-    "express-session": "^1.10.3",
     "hmpo-form-controller": "^0.5.0",
     "hmpo-model": "0.0.0",
     "hogan.js": "^3.0.2",


### PR DESCRIPTION
This is very dangerous. If you can't access redis (or your store of choice) for some reason (it's down for example) then the wizard will make a session anyway using in memory sessions which are known to be leaky leaky leaky.

It should error at this point which the developer can capture and deal with.