### PR TITLE
Add support for whitelising any step in form history as backlink

### DIFF
--- a/lib/middleware/back-links.js
+++ b/lib/middleware/back-links.js
@@ -25,6 +25,23 @@ module.exports = function backLink(route, controller, steps) {
         }
     };
 
+    var checkFormHistory = function (sessionData) {
+        var previousSteps = _.chain(sessionData)
+            .pick(function(value, key, object) { return key.indexOf('hmpo-wizard') > -1; })
+            .pluck('steps')
+            .flatten()
+            .uniq()
+            .value();       
+
+        var allowedLinks = _.map(controller.options.backLinks, function(item) {
+            return item.replace('\.', '');
+        });       
+
+        var backLinks = _.intersection(previousSteps, allowedLinks);
+       
+        return (backLinks.length) ? _.last(backLinks).replace(/^\//, '') : undefined;
+    };
+
     var getBackLink = function (req) {
         var previous = _.intersection(req.sessionModel.get('steps'), previousSteps),
             backLink;
@@ -34,7 +51,7 @@ module.exports = function backLink(route, controller, steps) {
         } else if (previous.length) {
             backLink = _.last(previous).replace(/^\//, '');
         } else if (controller.options.backLinks && req.get('referrer')) {
-            backLink = checkReferrer(req.get('referrer'), req.baseUrl);
+            backLink = checkReferrer(req.get('referrer'), req.baseUrl) || checkFormHistory(req.session);
         }
 
         return backLink;

--- a/test/helpers/request.js
+++ b/test/helpers/request.js
@@ -4,6 +4,6 @@ var _ = require('underscore'),
 
 module.exports = function (settings) {
     var req = reqres.req(settings);
-    req.sessionModel = req.sessionModel || new SessionModel({}, { session: req.session, key: 'test' });
+    req.sessionModel = req.sessionModel || new SessionModel({}, { session: req.session, key: 'hmpo-wizard-test' });
     return req;
 };

--- a/test/middleware/spec.back-link.js
+++ b/test/middleware/spec.back-link.js
@@ -112,15 +112,6 @@ describe('Back Links', function () {
         res.locals.backLink.should.equal('whitelist');
     });
 
-    it('whitelists historical steps if no configured backwards route', function () {
-        req.get.withArgs('referrer').returns('http://example.com/referrer');
-        req.session['hmpo-wizard-test-form'] = { steps: ['/history1', '/history2']};
-        steps['/step2'].next = null;
-        controller.options.backLinks = ['/history1'];
-        backLinks('/step3', controller, steps)(req, res, next);
-        res.locals.backLink.should.equal('history1');
-    });
-
     it('supports links prefixed with `./`', function () {
         req.get.withArgs('referrer').returns('http://example.com/whitelist');
         req.sessionModel.set('steps', ['/step1', '/step2']);
@@ -150,6 +141,22 @@ describe('Back Links', function () {
         res.locals.backLink.should.equal('/whitelist');
     });
 
+    it('permits whitelisting of steps in history', function () {
+        req.get.withArgs('referrer').returns('http://example.com/base/step4');
+        req.sessionModel.set('steps', ['/step1', '/step2', '/step3a', '/step4']);
+        controller.options.backLinks = ['/step2'];
+        backLinks('/step3a', controller, steps)(req, res, next);
+        res.locals.backLink.should.equal('step2');
+    });
+
+    it('returns most recent of whitelisted steps in history', function () {
+        req.get.withArgs('referrer').returns('http://example.com/base/step4');
+        req.sessionModel.set('steps', ['/step1', '/step2', '/step3a', '/step4']);
+        controller.options.backLinks = ['/step2', '/step1'];
+        backLinks('/step3a', controller, steps)(req, res, next);
+        res.locals.backLink.should.equal('step2');
+    });
+
     it('returns undefined if referrer header is not on whitelist', function () {
         req.get.withArgs('referrer').returns('http://example.com/not-whitelisted');
         req.sessionModel.set('steps', ['/step1', '/step2']);
@@ -157,6 +164,15 @@ describe('Back Links', function () {
         controller.options.backLinks = ['whitelist'];
         backLinks('/', controller, steps)(req, res, next);
         expect(res.locals.backLink).to.be.undefined;
+    });
+
+    it('permits whitelisting of steps from separate form instance', function () {
+        req.get.withArgs('referrer').returns('http://example.com/referrer');
+        req.session['hmpo-wizard-test-form'] = { steps: ['/history1', '/history2']};
+        steps['/step2'].next = null;
+        controller.options.backLinks = ['/history1'];
+        backLinks('/step3', controller, steps)(req, res, next);
+        res.locals.backLink.should.equal('history1');
     });
 
     describe('isBackLink request object property', function () {

--- a/test/middleware/spec.back-link.js
+++ b/test/middleware/spec.back-link.js
@@ -112,6 +112,15 @@ describe('Back Links', function () {
         res.locals.backLink.should.equal('whitelist');
     });
 
+    it('whitelists historical steps if no configured backwards route', function () {
+        req.get.withArgs('referrer').returns('http://example.com/referrer');
+        req.session['hmpo-wizard-test-form'] = { steps: ['/history1', '/history2']};
+        steps['/step2'].next = null;
+        controller.options.backLinks = ['/history1'];
+        backLinks('/step3', controller, steps)(req, res, next);
+        res.locals.backLink.should.equal('history1');
+    });
+
     it('supports links prefixed with `./`', function () {
         req.get.withArgs('referrer').returns('http://example.com/whitelist');
         req.sessionModel.set('steps', ['/step1', '/step2']);

--- a/test/middleware/spec.back-link.js
+++ b/test/middleware/spec.back-link.js
@@ -166,9 +166,9 @@ describe('Back Links', function () {
         expect(res.locals.backLink).to.be.undefined;
     });
 
-    it('permits whitelisting of steps from separate form instance', function () {
+    it('permits whitelisting of steps from a separate form instance', function () {
         req.get.withArgs('referrer').returns('http://example.com/referrer');
-        req.session['hmpo-wizard-test-form'] = { steps: ['/history1', '/history2']};
+        req.session['hmpo-wizard-test-form'] = { steps: ['/history1', '/history2', '/step1', '/step2', '/step3', '/step4']};
         steps['/step2'].next = null;
         controller.options.backLinks = ['/history1'];
         backLinks('/step3', controller, steps)(req, res, next);

--- a/test/middleware/spec.back-link.js
+++ b/test/middleware/spec.back-link.js
@@ -168,9 +168,10 @@ describe('Back Links', function () {
 
     it('permits whitelisting of steps from a separate form instance', function () {
         req.get.withArgs('referrer').returns('http://example.com/referrer');
-        req.session['hmpo-wizard-test-form'] = { steps: ['/history1', '/history2', '/step1', '/step2', '/step3', '/step4']};
+        req.sessionModel.set('steps', ['/step1', '/step2', '/step3', '/step4']);
+        req.session['hmpo-wizard-test-form'] = { steps: ['/history1', '/history2']};
         steps['/step2'].next = null;
-        controller.options.backLinks = ['/history1'];
+        controller.options.backLinks = ['./history1'];
         backLinks('/step3', controller, steps)(req, res, next);
         res.locals.backLink.should.equal('history1');
     });


### PR DESCRIPTION
Another back-links request! Hopefully it addresses the needs of [#38](https://github.com/UKHomeOffice/passports-form-wizard/issues/38) and [PR39](https://github.com/UKHomeOffice/passports-form-wizard/pull/39), but also caters for the user journey cutting across multiple instances of the form wizard (HMPO have a number of use cases for this).

To recap: currently you can whitelist either a) the preceding step in the form journery or b) the directly referring page. However, it may also be useful to whitelist steps from further back in the form journey. 
