### PR TITLE
Add support for passing dynamic variables into error messages

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -4,14 +4,12 @@ var util = require('util'),
     Controller = require('hmpo-form-controller');
 
 function getArgs(type, args) {
-    if (type === 'maxlength') {
-        return { maxlength: args[0] };
-    } else if (type === 'minlength') {
-        return { minlength: args[0] };
-    } else if (type === 'exactlength') {
-        return { exactlength: args[0] };
-    } else if (type === 'past') {
+    if (type === 'past') {
         return { age: args.join(' ') };
+    } else if (_.isArray(args) && typeof type === 'string') {
+        var obj = {};
+        obj[type] = args[0];
+        return obj;
     } else {
         return {};
     }

--- a/test/spec.error.js
+++ b/test/spec.error.js
@@ -67,6 +67,12 @@ describe('Error', function () {
             error.message.should.equal('This must be less than 5 days ago');
         });
 
+        it('populates custom messages with the required variable', function () {
+            req.translate.withArgs('validation.key.custom').returns('This must be {{custom}}');
+            var error = new ErrorClass('key', { type: 'custom', arguments: ['dynamic'] }, req);
+            error.message.should.equal('This must be dynamic');
+        });
+
         it('uses own translate method if no req.translate is defined', function () {
             delete req.translate;
             sinon.stub(ErrorClass.prototype, 'translate').returns('Custom translate');


### PR DESCRIPTION
It would be good to allow other arguments (i.e. not just maxlength, minlength, exactlength and past) to be passed into error messages.

An example implementation of this would be:

 var error = new ErrorClass('key', { type: 'custom-var', arguments: ['some value for custom-var'] }, req);