### PR TITLE
Add `res.locals` to context for error messages

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -19,7 +19,7 @@ function compile(t, context) {
     return require('hogan.js').compile(t).render(context);
 }
 
-function FormError(key, options, req) {
+function FormError(key, options, req, res) {
     req = req || {};
     if (typeof req.translate === 'function') {
         this.translate = req.translate;
@@ -29,7 +29,8 @@ function FormError(key, options, req) {
 
 util.inherits(FormError, Controller.Error);
 
-FormError.prototype.getMessage = function getValidationMessage(key, options) {
+FormError.prototype.getMessage = function getValidationMessage(key, options, req, res) {
+    res = res || {};
     var keys = [
             'validation.' + key + '.' + options.type,
             'validation.' + key + '.default',
@@ -38,7 +39,7 @@ FormError.prototype.getMessage = function getValidationMessage(key, options) {
         ],
         context = _.extend({
             label: this.translate('fields.' + key + '.label').toLowerCase()
-        }, getArgs(options.type, options.arguments));
+        }, res.locals, getArgs(options.type, options.arguments));
 
     return i18nLookup(this.translate, compile)(keys, context);
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "csrf": "^2.0.6",
     "debug": "^2.1.2",
     "express": "^4.12.2",
-    "hmpo-form-controller": "^0.5.0",
+    "hmpo-form-controller": "^0.6.0",
     "hmpo-model": "0.0.0",
     "hogan.js": "^3.0.2",
     "i18n-lookup": "^0.1.0",

--- a/test/spec.error.js
+++ b/test/spec.error.js
@@ -2,12 +2,13 @@ var ErrorClass = require('../lib/error');
 
 describe('Error', function () {
 
-    var req;
+    var req, res;
 
     beforeEach(function () {
         req = request({
             translate: sinon.stub().returnsArg(0)
         });
+        res = response();
     });
 
     describe('getMessage', function () {
@@ -71,6 +72,13 @@ describe('Error', function () {
             req.translate.withArgs('validation.key.custom').returns('This must be {{custom}}');
             var error = new ErrorClass('key', { type: 'custom', arguments: ['dynamic'] }, req);
             error.message.should.equal('This must be dynamic');
+        });
+
+        it('populates messages with values from `res.locals` when present', function () {
+            req.translate.withArgs('validation.key.required').returns('This must be a {{something}}');
+            res.locals.something = 'value';
+            var error = new ErrorClass('key', { type: 'required' }, req, res);
+            error.message.should.equal('This must be a value');
         });
 
         it('uses own translate method if no req.translate is defined', function () {


### PR DESCRIPTION
This allows values saved on `res.locals` to be displayed in validation messages. So if `res.locals.foo = bar` and your error message is "Pleases enter {{ foo }}" then "Please enter bar" is rendered.