### PR TITLE
GFM-23 - added createSteps middleware which adds a stepData object to…

### DIFF
--- a/lib/middleware/steps.js
+++ b/lib/middleware/steps.js
@@ -1,0 +1,101 @@
+var _ = require('underscore');
+
+module.exports = function createSteps(route, controller, steps, start) {
+  start = start || '/';
+
+  // traverse the step journey using the
+  // next param if present, returning an
+  // array of steps
+  var traverse = function traverse(step, steps, result) {
+    result = result || [];
+    var next = step.next;
+    if (next && steps[next]) {
+      return traverse(steps[next], steps, result.concat(step));
+    }
+    return result;
+  }
+
+  var getStepsJourney = function getStepsJourney(stepsJourney, prevStep) {
+    stepsJourney = stepsJourney || [];
+    // add currentStep to journey if not
+    // already added
+    if (stepsJourney.indexOf(route) === -1) {
+      if (prevStep === undefined) {
+        stepsJourney.push(route);
+      } else {
+        // add current step after the prev step
+        // to preserve journey order
+        var prevIndex = stepsJourney.indexOf(prevStep);
+        stepsJourney.splice(prevIndex + 1, 0, route);
+      }
+    }
+
+    return stepsJourney;
+  };
+
+  var getCurrentStepNumber = function getNextStep(stepsJourney) {
+    // find index of current step, return as
+    // 1-indexed for display.
+    return stepsJourney.indexOf(route) + 1;
+  };
+
+  var getTotalSteps = function getTotalSteps(stepsJourney) {
+    // get path by using only next params
+    var linearPath = traverse(steps[start], steps);
+    var linearPathSteps = _.pluck(linearPath, 'next');
+
+    var index = 0;
+    var forks = [];
+    var arr = stepsJourney.slice();
+
+    while (index < arr.length) {
+      // if value doesn't follow the standard linear order
+      // it is a fork, store value and continue with
+      // comparison
+      if (arr[index] !== linearPathSteps[index]) {
+        forks.push(arr[index]);
+        arr.splice(index, 1);
+      } else {
+        index++;
+      }
+    }
+
+    // if no forks then journey is linear
+    if (!forks.length) {
+      return linearPath.length;
+    }
+
+    // we only need the last fork, as previous
+    // forks will be included in the previous
+    // journey steps.
+    var lastFork = forks[forks.length - 1];
+    var stepsBefore = stepsJourney.indexOf(lastFork);
+    // traverse linearly from point of fork
+    var shortestRouteToEnd = traverse(steps[lastFork], steps);
+
+    // amount of steps before fork + fork + linear
+    // steos after fork.
+    return (stepsBefore + 1) + shortestRouteToEnd.length;
+  };
+
+  return function(req, res, next) {
+    // ignore any request apart from GET
+    if (req.method === 'GET') {
+      var stepData = req.sessionModel.get('stepData') || {};
+      var stepsJourney = getStepsJourney(stepData.stepsJourney, stepData.prevStep);
+      var currentStepNumber = getCurrentStepNumber(stepsJourney);
+      var totalSteps = getTotalSteps(stepsJourney);
+      var prevStep = route;
+
+      req.sessionModel.set('stepData', {
+        stepsJourney: stepsJourney,
+        currentStepNumber: currentStepNumber,
+        totalSteps: totalSteps,
+        prevStep: prevStep
+      });
+      next();
+    } else {
+      next();
+    }
+  };
+};

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -46,7 +46,8 @@ var Wizard = function (steps, fields, settings) {
 
         controller.use([
             require('./middleware/check-session')(route, controller, steps, first),
-            require('./middleware/check-progress')(route, controller, steps, first)
+            require('./middleware/check-progress')(route, controller, steps, first),
+            require('./middleware/steps')(route, controller, steps, first)
         ]);
         if (settings.csrf !== false) {
             controller.use(require('./middleware/csrf')(route, controller, steps, first));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "routing and request handling for a multi-step form processes",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/. --recursive --require test/helpers.js"
+    "test": "mocha test/. --recursive --require test/helpers.js",
+    "test:watch": "npm run test -- --watch"
   },
   "repository": {
     "type": "git",

--- a/test/middleware/spec.steps.js
+++ b/test/middleware/spec.steps.js
@@ -1,0 +1,204 @@
+var createSteps = require('../../lib/middleware/steps');
+var Model = require('../../lib/model');
+var Controller = require('../../lib/controller');
+
+describe('middleware/steps', function() {
+  var req, res, next, controller, steps, stepData;
+
+  beforeEach(function() {
+    req = request();
+    req.sessionModel = new Model({}, { session: req.session, key: 'test' });
+    res = response();
+    next = sinon.stub();
+    controller = new Controller({ template: 'index' });
+    steps = {
+      '/one': { next: '/two' },
+      '/two': { next: '/three' },
+      '/three': { next: '/four' },
+      '/four': { next: '/five' },
+      '/five': {},
+      '/forkOne': { next: '/two' },
+      '/forkTwo': { next: '/four' },
+    }
+  });
+
+  it('should set stepData on sessionModel if method is GET', function() {
+    req.method = 'GET';
+    var middleware = createSteps('/one', controller, steps, '/one');
+    middleware(req, res, function() {
+      expect(req.sessionModel.get('stepData')).to.be.an.instanceOf(Object);
+    });
+  });
+
+  it('shouldn\'t set stepData if method is not GET', function() {
+    req.method = 'POST';
+    var middleware = createSteps('/one', controller, steps, '/one');
+    middleware(req, res, function() {
+      expect(req.sessionModel.get('stepData')).to.be.equal(undefined);
+    });
+  });
+
+  describe('First Step', function(done) {
+    beforeEach(function(done) {
+      createSteps('/one', controller, steps, '/one')(req, res, function() {
+        stepData = req.sessionModel.get('stepData');
+        done();
+      });
+    });
+
+    it('should have set the currentStepNumber to 1', function() {
+      expect(stepData.currentStepNumber).to.be.equal(1);
+    });
+
+    it('should have set the totalSteps to 4', function() {
+      expect(stepData.totalSteps).to.be.equal(5);
+    });
+
+    it('should have set the prevStep to \'/one\'', function() {
+      expect(stepData.prevStep).to.be.equal('/one');
+    });
+
+    it('should have set the stepsJourney to [\'/one\']', function() {
+      expect(stepData.stepsJourney).to.be.eql(['/one']);
+    });
+  });
+
+  describe('Second Step', function() {
+    beforeEach(function(done) {
+      createSteps('/one', controller, steps, '/one')(req, res, function() {});
+      createSteps('/two', controller, steps, '/one')(req, res, function() {
+        stepData = req.sessionModel.get('stepData');
+        done();
+      });
+    });
+
+    it('should have set the currentStepNumber to 2', function() {
+      expect(stepData.currentStepNumber).to.be.equal(2)
+    });
+
+    it('should have set the totalSteps to 4', function() {
+      expect(stepData.totalSteps).to.be.equal(5);
+    });
+
+    it('should have set prevStep to /two', function() {
+      expect(stepData.prevStep).to.be.equal('/two');
+    });
+
+    it('should have set the stepsJourney to [\'/one\', \'/two\']', function() {
+      expect(stepData.stepsJourney).to.be.eql(['/one', '/two']);
+    });
+  });
+
+  describe('Third Step', function() {
+    beforeEach(function(done) {
+      createSteps('/one', controller, steps, '/one')(req, res, function() {});
+      createSteps('/two', controller, steps, '/one')(req, res, function() {});
+      createSteps('/three', controller, steps, '/one')(req, res, function() {
+        stepData = req.sessionModel.get('stepData');
+        done();
+      });
+    });
+
+    it('should have set the currentStepNumber to 3', function() {
+      expect(stepData.currentStepNumber).to.be.equal(3)
+    });
+
+    it('should have set the totalSteps to 4', function() {
+      expect(stepData.totalSteps).to.be.equal(5);
+    });
+
+    it('should have set prevStep to /three', function() {
+      expect(stepData.prevStep).to.be.equal('/three');
+    });
+
+    it('should have set the stepsJourney to [\'/one\', \'/two\', \'/three\']', function() {
+      expect(stepData.stepsJourney).to.be.eql(['/one', '/two', '/three']);
+    });
+  });
+
+  describe('Forks', function() {
+    describe('Adding to totalSteps', function() {
+      beforeEach(function(done) {
+        createSteps('/one', controller, steps, '/one')(req, res, function() {});
+        createSteps('/forkOne', controller, steps, '/one')(req, res, function() {
+          stepData = req.sessionModel.get('stepData');
+          done();
+        });
+      });
+
+      it('should have set the currentStepNumber to 2', function() {
+        expect(stepData.currentStepNumber).to.be.equal(2);
+      });
+
+      it('should have set the totalSteps to 5', function() {
+        expect(stepData.totalSteps).to.be.equal(6);
+      });
+
+      it('should have set prevStep to /forkOne', function() {
+        expect(stepData.prevStep).to.be.equal('/forkOne');
+      });
+
+      it('should have set stepsJourney to [\'/one\', \'/forkOne\']', function() {
+        expect(stepData.stepsJourney).to.be.eql(['/one', '/forkOne']);
+      });
+    });
+
+    describe('Skipping steps', function() {
+      beforeEach(function(done) {
+        createSteps('/one', controller, steps, '/one')(req, res, function() {});
+        createSteps('/forkTwo', controller, steps, '/one')(req, res, function() {
+          stepData = req.sessionModel.get('stepData');
+          done();
+        });
+      });
+
+      it('should have set currentStepNumber to 2', function() {
+        expect(stepData.currentStepNumber).to.be.equal(2);
+      });
+
+      it('should have set the totalSteps to 4', function() {
+        expect(stepData.totalSteps).to.be.equal(4);
+      });
+
+      it('should have set prevStep to /forkTwo', function() {
+        expect(stepData.prevStep).to.be.equal('/forkTwo');
+      });
+
+      it('should have set stepsJourney to [\'/one\', \'/forkTwo\']', function() {
+        expect(stepData.stepsJourney).to.be.eql(['/one', '/forkTwo']);
+      });
+    });
+
+    describe('Complex journey', function() {
+      beforeEach(function(done) {
+        createSteps('/one', controller, steps, '/one')(req, res, function() {});
+        createSteps('/two', controller, steps, '/one')(req, res, function() {});
+        createSteps('/three', controller, steps, '/one')(req, res, function() {});
+        createSteps('/two', controller, steps, '/one')(req, res, function() {});
+        createSteps('/one', controller, steps, '/one')(req, res, function() {});
+        createSteps('/forkOne', controller, steps, '/one')(req, res, function() {});
+        createSteps('/two', controller, steps, '/one')(req, res, function() {});
+        createSteps('/forkTwo', controller, steps, '/one')(req, res, function() {
+          stepData = req.sessionModel.get('stepData');
+          done();
+        });
+      });
+
+      it('should have set currentStepNumber to 4', function() {
+        expect(stepData.currentStepNumber).to.be.equal(4);
+      });
+
+      it('should have set the totalSteps to 6', function() {
+        expect(stepData.totalSteps).to.be.equal(6);
+      });
+
+      it('should have set prevStep to /forkTwo', function() {
+        expect(stepData.prevStep).to.be.equal('/forkTwo');
+      });
+
+      it('should have set stepsJourney to [\'/one\', \'/forkOne\', \'/two\', \'/forkTwo\', \'/three\']', function() {
+        expect(stepData.stepsJourney).to.be.eql(['/one', '/forkOne', '/two', '/forkTwo', '/three']);
+      });
+    });
+  });
+});


### PR DESCRIPTION
… the sessionModel

https://jira.digital.homeoffice.gov.uk/browse/GFM-23

Available properties:
currentStepNumber - the number of the current step
totalSteps - the total number steps taking forks into account
prevStep - the previous visited step, used internally
stepsJourney - a sequential array of visited pages

* Create step journey by adding current route to correct place in journey array. Uses stored prevStep
* Calculate current step number by taking index from stepsJourney - add 1 for display
* Calculate totalSteps by traversing the steps using next property, compare to current journey, if order is different then work out new journey depending on forks - only last fork is required as prev steps will be recorded.