### PR TITLE
Fixes #49 - expose stepNumber and totalSteps in res.locals

### DIFF
--- a/lib/middleware/check-progress.js
+++ b/lib/middleware/check-progress.js
@@ -5,6 +5,81 @@ module.exports = function checkProgress(route, controller, steps, start) {
 
     start = start || '/';
 
+    // traverse the step journey using the
+    // next param if present, returning an
+    // array of steps
+    var traverse = function traverse(step, steps, result) {
+        result = result || [];
+        var next = step.next;
+        if (next && steps[next]) {
+            return traverse(steps[next], steps, result.concat(step));
+        }
+        return result;
+    }
+
+    var getStepsJourney = function getStepsJourney(stepsJourney, prevStep) {
+        stepsJourney = stepsJourney || [];
+        // add currentStep to journey if not
+        // already added
+        if (stepsJourney.indexOf(route) === -1) {
+            if (prevStep === undefined) {
+                stepsJourney.push(route);
+            } else {
+                // add current step after the prev step
+                // to preserve journey order
+                var prevIndex = stepsJourney.indexOf(prevStep);
+                stepsJourney.splice(prevIndex + 1, 0, route);
+            }
+        }
+
+        return stepsJourney;
+    };
+
+    var getCurrentStepNumber = function getNextStep(stepsJourney) {
+        // find index of current step, return as
+        // 1-indexed for display.
+        return stepsJourney.indexOf(route) + 1;
+    };
+
+    var getTotalSteps = function getTotalSteps(stepsJourney) {
+        // get path by using only next params
+        var linearPath = traverse(steps[start], steps);
+        var linearPathSteps = _.pluck(linearPath, 'next');
+
+        var index = 0;
+        var forks = [];
+        var arr = stepsJourney.slice();
+
+        while (index < arr.length) {
+            // if value doesn't follow the standard linear order
+            // it is a fork, store value and continue with
+            // comparison
+            if (arr[index] !== linearPathSteps[index]) {
+                forks.push(arr[index]);
+                arr.splice(index, 1);
+            } else {
+                index++;
+            }
+        }
+
+        // if no forks then journey is linear
+        if (!forks.length) {
+            return linearPath.length;
+        }
+
+        // we only need the last fork, as previous
+        // forks will be included in the previous
+        // journey steps.
+        var lastFork = forks[forks.length - 1];
+        var stepsBefore = stepsJourney.indexOf(lastFork);
+        // traverse linearly from point of fork
+        var shortestRouteToEnd = traverse(steps[lastFork], steps);
+
+        // amount of steps before fork + fork + linear
+        // steos after fork.
+        return (stepsBefore + 1) + shortestRouteToEnd.length;
+    };
+
     var previousSteps = _.reduce(steps, function (list, step, path) {
         if (step.next === route) {
             list.push(path);
@@ -45,6 +120,22 @@ module.exports = function checkProgress(route, controller, steps, start) {
     });
 
     return function (req, res, next) {
+        // only update step meta on GET requests
+        if (req.method === 'GET') {
+          var stepData = req.sessionModel.get('stepData') || {};
+          var stepsJourney = getStepsJourney(stepData.stepsJourney, stepData.prevStep);
+          var stepNumber = getCurrentStepNumber(stepsJourney);
+          var totalSteps = getTotalSteps(stepsJourney);
+          var prevStep = route;
+
+          req.sessionModel.set('stepData', {
+            stepsJourney: stepsJourney,
+            prevStep: prevStep
+          });
+
+          res.locals.stepNumber = stepNumber;
+          res.locals.totalSteps = totalSteps;
+        }
 
         _.each(invalidatingFields, function (field, key) {
             req.sessionModel.on('change:' + key, function () {

--- a/test/middleware/spec.check-progress.js
+++ b/test/middleware/spec.check-progress.js
@@ -1,40 +1,243 @@
-var checkSession = require('../../lib/middleware/check-progress'),
+var checkProgress = require('../../lib/middleware/check-progress'),
     Model = require('../../lib/model'),
     Controller = require('../../lib/controller');
 
-describe('middleware/check-session', function () {
+describe('middleware/check-progress', function () {
 
     var req, res, next, controller, steps;
 
-    beforeEach(function () {
-        req = request();
-        req.sessionModel = new Model({}, { session: req.session, key: 'test' });
-        res = response();
-        next = sinon.stub();
-        controller = new Controller({ template: 'index' });
-        steps = {
-            '/one': { next: '/two' },
-            '/two': { next: '/three' },
-            '/three': { next: '/four' },
-            '/four': {}
-        }
+    describe('checkProgress', function () {
+
+      beforeEach(function () {
+          req = request();
+          req.sessionModel = new Model({}, { session: req.session, key: 'test' });
+          res = response();
+          next = sinon.stub();
+          controller = new Controller({ template: 'index' });
+          steps = {
+              '/one': { next: '/two' },
+              '/two': { next: '/three' },
+              '/three': { next: '/four' },
+              '/four': {}
+          }
+      });
+
+      it('calls callback with no arguments if prerequisite steps are complete', function (done) {
+          req.sessionModel.set('steps', [ '/one', '/two' ]);
+          var middleware = checkProgress('/three', controller, steps, '/one');
+          middleware(req, res, function (err) {
+              expect(err).to.be.undefined;
+              done();
+          });
+      });
+
+      it('calls callback with MISSING_PREREQ error code if accessing step that has not had prerequisite steps complete', function (done) {
+          req.sessionModel.set('steps', []);
+          var middleware = checkProgress('/three', controller, steps, '/one');
+          middleware(req, res, function (err) {
+              err.code.should.equal('MISSING_PREREQ');
+              done();
+          });
+      });
+
     });
 
-    it('calls callback with no arguments if prerequisite steps are complete', function (done) {
-        req.sessionModel.set('steps', [ '/one', '/two' ]);
-        var middleware = checkSession('/three', controller, steps, '/one');
-        middleware(req, res, function (err) {
-            expect(err).to.be.undefined;
-            done();
+    describe('Step Meta', function () {
+        beforeEach(function () {
+            req = request();
+            req.sessionModel = new Model({}, { session: req.session, key: 'test' });
+            res = response();
+            next = sinon.stub();
+            controller = new Controller({ template: 'index' });
+            steps = {
+                '/one': { next: '/two' },
+                '/two': { next: '/three' },
+                '/three': { next: '/four' },
+                '/four': { next: '/five' },
+                '/five': {},
+                '/forkOne': { next: '/two' },
+                '/forkTwo': { next: '/four' },
+            };
         });
-    });
 
-    it('calls callback with MISSING_PREREQ error code if accessing step that has not had prerequisite steps complete', function (done) {
-        req.sessionModel.set('steps', []);
-        var middleware = checkSession('/three', controller, steps, '/one');
-        middleware(req, res, function (err) {
-            err.code.should.equal('MISSING_PREREQ');
-            done();
+        it('should set stepData on sessionModel if method is GET', function () {
+            req.method = 'GET';
+            var middleware = checkProgress('/one', controller, steps, '/one');
+            middleware(req, res, function () {
+                expect(req.sessionModel.get('stepData')).to.be.an.instanceOf(Object);
+            });
+        });
+
+        it('shouldn\'t set stepData if method is not GET', function () {
+            req.method = 'POST';
+            var middleware = checkProgress('/one', controller, steps, '/one');
+            middleware(req, res, function () {
+                expect(req.sessionModel.get('stepData')).to.be.equal(undefined);
+            });
+        });
+
+        describe('First Step', function (done) {
+            beforeEach(function (done) {
+                checkProgress('/one', controller, steps, '/one')(req, res, function () {
+                    stepData = req.sessionModel.get('stepData');
+                    done();
+                });
+            });
+
+            it('should have set the currentStepNumber to 1', function () {
+                expect(res.locals.stepNumber).to.be.equal(1);
+            });
+
+            it('should have set the totalSteps to 4', function () {
+                expect(res.locals.totalSteps).to.be.equal(5);
+            });
+
+            it('should have set the prevStep to \'/one\'', function () {
+                expect(stepData.prevStep).to.be.equal('/one');
+            });
+
+            it('should have set the stepsJourney to [\'/one\']', function () {
+                expect(stepData.stepsJourney).to.be.eql(['/one']);
+            });
+        });
+
+        describe('Second Step', function () {
+            beforeEach(function (done) {
+                checkProgress('/one', controller, steps, '/one')(req, res, function () {});
+                checkProgress('/two', controller, steps, '/one')(req, res, function () {
+                    stepData = req.sessionModel.get('stepData');
+                    done();
+                });
+            });
+
+            it('should have set the currentStepNumber to 2', function () {
+                expect(res.locals.stepNumber).to.be.equal(2)
+            });
+
+            it('should have set the totalSteps to 4', function () {
+                expect(res.locals.totalSteps).to.be.equal(5);
+            });
+
+            it('should have set prevStep to /two', function () {
+                expect(stepData.prevStep).to.be.equal('/two');
+            });
+
+            it('should have set the stepsJourney to [\'/one\', \'/two\']', function () {
+                expect(stepData.stepsJourney).to.be.eql(['/one', '/two']);
+            });
+        });
+
+        describe('Third Step', function () {
+            beforeEach(function (done) {
+                checkProgress('/one', controller, steps, '/one')(req, res, function () {});
+                checkProgress('/two', controller, steps, '/one')(req, res, function () {});
+                checkProgress('/three', controller, steps, '/one')(req, res, function () {
+                    stepData = req.sessionModel.get('stepData');
+                    done();
+                });
+            });
+
+            it('should have set the currentStepNumber to 3', function () {
+                expect(res.locals.stepNumber).to.be.equal(3)
+            });
+
+            it('should have set the totalSteps to 4', function () {
+                expect(res.locals.totalSteps).to.be.equal(5);
+            });
+
+            it('should have set prevStep to /three', function () {
+                expect(stepData.prevStep).to.be.equal('/three');
+            });
+
+            it('should have set the stepsJourney to [\'/one\', \'/two\', \'/three\']', function () {
+                expect(stepData.stepsJourney).to.be.eql(['/one', '/two', '/three']);
+            });
+        });
+
+        describe('Forks', function () {
+            describe('Adding to totalSteps', function () {
+                beforeEach(function (done) {
+                    checkProgress('/one', controller, steps, '/one')(req, res, function () {});
+                    checkProgress('/forkOne', controller, steps, '/one')(req, res, function () {
+                        stepData = req.sessionModel.get('stepData');
+                        done();
+                    });
+                });
+
+                it('should have set the currentStepNumber to 2', function () {
+                    expect(res.locals.stepNumber).to.be.equal(2);
+                });
+
+                it('should have set the totalSteps to 5', function () {
+                    expect(res.locals.totalSteps).to.be.equal(6);
+                });
+
+                it('should have set prevStep to /forkOne', function () {
+                    expect(stepData.prevStep).to.be.equal('/forkOne');
+                });
+
+                it('should have set stepsJourney to [\'/one\', \'/forkOne\']', function () {
+                    expect(stepData.stepsJourney).to.be.eql(['/one', '/forkOne']);
+                });
+            });
+
+            describe('Skipping steps', function () {
+                beforeEach(function (done) {
+                    checkProgress('/one', controller, steps, '/one')(req, res, function () {});
+                    checkProgress('/forkTwo', controller, steps, '/one')(req, res, function () {
+                        stepData = req.sessionModel.get('stepData');
+                        done();
+                    });
+                });
+
+                it('should have set currentStepNumber to 2', function () {
+                    expect(res.locals.stepNumber).to.be.equal(2);
+                });
+
+                it('should have set the totalSteps to 4', function () {
+                    expect(res.locals.totalSteps).to.be.equal(4);
+                });
+
+                it('should have set prevStep to /forkTwo', function () {
+                    expect(stepData.prevStep).to.be.equal('/forkTwo');
+                });
+
+                it('should have set stepsJourney to [\'/one\', \'/forkTwo\']', function () {
+                    expect(stepData.stepsJourney).to.be.eql(['/one', '/forkTwo']);
+                });
+            });
+
+            describe('Complex journey', function () {
+                beforeEach(function (done) {
+                    checkProgress('/one', controller, steps, '/one')(req, res, function () {});
+                    checkProgress('/two', controller, steps, '/one')(req, res, function () {});
+                    checkProgress('/three', controller, steps, '/one')(req, res, function () {});
+                    checkProgress('/two', controller, steps, '/one')(req, res, function () {});
+                    checkProgress('/one', controller, steps, '/one')(req, res, function () {});
+                    checkProgress('/forkOne', controller, steps, '/one')(req, res, function () {});
+                    checkProgress('/two', controller, steps, '/one')(req, res, function () {});
+                    checkProgress('/forkTwo', controller, steps, '/one')(req, res, function () {
+                        stepData = req.sessionModel.get('stepData');
+                        done();
+                    });
+                });
+
+                it('should have set currentStepNumber to 4', function () {
+                    expect(res.locals.stepNumber).to.be.equal(4);
+                });
+
+                it('should have set the totalSteps to 6', function () {
+                    expect(res.locals.totalSteps).to.be.equal(6);
+                });
+
+                it('should have set prevStep to /forkTwo', function () {
+                    expect(stepData.prevStep).to.be.equal('/forkTwo');
+                });
+
+                it('should have set stepsJourney to [\'/one\', \'/forkOne\', \'/two\', \'/forkTwo\', \'/three\']', function () {
+                    expect(stepData.stepsJourney).to.be.eql(['/one', '/forkOne', '/two', '/forkTwo', '/three']);
+                });
+            });
         });
     });
 


### PR DESCRIPTION
* Added logic to lib/middleware/check-progress.js to work out current step number and totalSteps
* previousStep is logged to work out the position of the next step
* a 'step-journey' is logged which maps out an array of steps a user takes, taking into account revisiting steps and taking an alternate path
* currentStep is the index of the step in this journey
* totalSteps is worked out by traversing the steps from start to finish using the `next` propeties, and comparing against the step journey, any differences are forks
* fork can either add to or subtract from the totalSteps, this is worked out by traversing the steps ahead of the fork, and adding to the number of steps behind the fork