### PR TITLE
Check for forks when generating back link

### DIFF
--- a/lib/middleware/back-links.js
+++ b/lib/middleware/back-links.js
@@ -1,11 +1,11 @@
 var url = require('url'),
     path = require('path'),
     _ = require('underscore'),
-    getPreviousSteps = require('../util/helpers').getPreviousSteps;
+    helpers = require('../util/helpers');
 
 module.exports = function backLink(route, controller, steps) {
 
-    var previousSteps = getPreviousSteps(steps, route);
+    var previousSteps = helpers.getRouteSteps(route, steps);
 
     var checkReferrer = function (referrer, baseUrl) {
         var referrerPath = url.parse(referrer).path;

--- a/lib/middleware/back-links.js
+++ b/lib/middleware/back-links.js
@@ -1,15 +1,11 @@
 var url = require('url'),
     path = require('path'),
-    _ = require('underscore');
+    _ = require('underscore'),
+    getPreviousSteps = require('../util/helpers').getPreviousSteps;
 
 module.exports = function backLink(route, controller, steps) {
 
-    var previousSteps = _.reduce(steps, function (list, step, path) {
-        if (step.next === route) {
-            list.push(path);
-        }
-        return list;
-    }, []);
+    var previousSteps = getPreviousSteps(steps, route);
 
     var checkReferrer = function (referrer, baseUrl) {
         var referrerPath = url.parse(referrer).path;
@@ -31,15 +27,15 @@ module.exports = function backLink(route, controller, steps) {
             .pluck('steps')
             .flatten()
             .uniq()
-            .value();       
+            .value();
 
         var allowedLinks = _.map(controller.options.backLinks, function(item) {
             return item.replace('\.', '');
-        });       
+        });
 
         var backLinks = _.intersection(previousSteps, allowedLinks);
-       
-        return (backLinks.length) ? _.last(backLinks).replace(/^\//, '') : undefined;
+
+        return backLinks.length ? _.last(backLinks).replace(/^\//, '') : undefined;
     };
 
     var getBackLink = function (req) {

--- a/lib/middleware/check-progress.js
+++ b/lib/middleware/check-progress.js
@@ -1,16 +1,12 @@
 var _ = require('underscore'),
-    debug = require('debug')('hmpo:progress-check');
+    debug = require('debug')('hmpo:progress-check'),
+    getPreviousSteps = require('../util/helpers').getPreviousSteps;
 
 module.exports = function checkProgress(route, controller, steps, start) {
 
     start = start || '/';
 
-    var previousSteps = _.reduce(steps, function (list, step, path) {
-        if (step.next === route) {
-            list.push(path);
-        }
-        return list;
-    }, []);
+    var previousSteps = getPreviousSteps(steps, route);
 
     var prereqs = (controller.options.prereqs || []).concat(previousSteps);
 
@@ -45,7 +41,6 @@ module.exports = function checkProgress(route, controller, steps, start) {
     });
 
     return function (req, res, next) {
-
         _.each(invalidatingFields, function (field, key) {
             req.sessionModel.on('change:' + key, function () {
                 debug('Unsetting fields %s', field.invalidates.join(', '));

--- a/lib/middleware/check-progress.js
+++ b/lib/middleware/check-progress.js
@@ -1,12 +1,12 @@
 var _ = require('underscore'),
     debug = require('debug')('hmpo:progress-check'),
-    getPreviousSteps = require('../util/helpers').getPreviousSteps;
+    helpers = require('../util/helpers');
 
 module.exports = function checkProgress(route, controller, steps, start) {
 
     start = start || '/';
 
-    var previousSteps = getPreviousSteps(steps, route);
+    var previousSteps = helpers.getRouteSteps(route, steps);
 
     var prereqs = (controller.options.prereqs || []).concat(previousSteps);
 

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -3,12 +3,12 @@
 var _ = require('underscore');
 
 module.exports = {
-    getPreviousSteps: function(route, steps) {
+    getRouteSteps: function(route, steps) {
         return _.reduce(steps, function (list, step, path) {
             var isNext = step.next === route;
-            var forks = _.pluck((step.forks || []), 'target');
+            var targets = _.pluck((step.forks || []), 'target');
 
-            var isFork = forks.some(function(fork) {
+            var isFork = targets.some(function(fork) {
                 return fork === route;
             });
 

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var _ = require('underscore');
+
+module.exports = {
+    getPreviousSteps: function(route, steps) {
+        return _.reduce(steps, function (list, step, path) {
+            var isNext = step.next === route;
+            var forks = _.pluck((step.forks || []), 'target');
+
+            var isFork = forks.some(function(fork) {
+                return fork === route;
+            });
+
+            if (isNext || isFork) {
+                list.push(path);
+            }
+            return list;
+        }, []);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "csrf": "^2.0.6",
     "debug": "^2.1.2",
     "express": "^4.12.2",
-    "hmpo-form-controller": "^0.6.0",
+    "hmpo-form-controller": "^0.7.0",
     "hmpo-model": "0.0.0",
     "hogan.js": "^3.0.2",
     "i18n-lookup": "^0.1.0",
@@ -29,6 +29,7 @@
   "devDependencies": {
     "chai": "^2.1.2",
     "mocha": "^2.2.1",
+    "proxyquire": "^1.7.7",
     "reqres": "^1.2.0",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "chai": "^2.1.2",
     "mocha": "^2.2.1",
-    "proxyquire": "^1.7.7",
     "reqres": "^1.2.0",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0"

--- a/test/util/spec.helpers.js
+++ b/test/util/spec.helpers.js
@@ -1,0 +1,117 @@
+var helpers = require('../../lib/util/helpers');
+
+describe('helpers', function () {
+
+    describe('getPreviousSteps', function () {
+        var getPreviousSteps, steps;
+
+        beforeEach(function () {
+            getPreviousSteps = helpers.getPreviousSteps;
+        });
+
+        it('is a function', function () {
+            getPreviousSteps.should.be.a('function');
+        });
+
+        it('returns an array', function () {
+            getPreviousSteps().should.be.an('array');
+        });
+
+        describe('only using next property', function () {
+            beforeEach(function () {
+                steps = {
+                    '/step1': {
+                        next: '/step2'
+                    },
+                    '/step2': {
+                        next: '/step3'
+                    },
+                    '/step3': {
+                        next: '/step4'
+                    },
+                    '/step3a': {
+                        next: '/step4'
+                    },
+                    '/step4': {}
+                };
+            });
+
+            it('returns /step3a and /step3 when called with steps object and /step4', function () {
+                getPreviousSteps('/step4', steps).should.be.eql(['/step3', '/step3a']);
+            });
+
+            it('should return an empty array if step isn\'t linked to', function () {
+                getPreviousSteps('/step5', steps).should.be.an('array')
+                  .and.have.property('length')
+                  .and.equal(0);
+            });
+        });
+
+        describe('using forks', function () {
+            beforeEach(function () {
+              steps = {
+                  '/step1': {
+                      forks: [{
+                        target: '/step2'
+                      }]
+                  },
+                  '/step2': {
+                      forks: [{
+                        target: '/step3'
+                      }, {
+                        target: '/step4'
+                      }]
+                  },
+                  '/step3': {
+                      forks: [{
+                        target: '/step3a'
+                      }]
+                  },
+                  '/step3a': {
+                      forks: [{
+                        target: '/step4'
+                      }]
+                  },
+                  '/step4': {}
+              };
+            });
+
+            it('should return a step that has route as a fork target', function () {
+                getPreviousSteps('/step2', steps).should.be.eql(['/step1']);
+            })
+
+            it('should return all steps that have given step as fork target', function () {
+                getPreviousSteps('/step4', steps).should.be.eql(['/step2', '/step3a']);
+            });
+        });
+
+        describe('using next property and forks', function () {
+            beforeEach(function () {
+                steps = {
+                    '/step1': {
+                        next: '/step2',
+                        forks: [{
+                          target: '/step3'
+                        }]
+                    },
+                    '/step2': {
+                        next: '/step3',
+                        forks: [{
+                          target: '/step3a'
+                        }, {
+                          target: '/step4'
+                        }]
+                    },
+                    '/step3': {},
+                    '/step3a': {},
+                    '/step4': {}
+                }
+            });
+
+            it('should return all steps that link to route', function () {
+                getPreviousSteps('/step3', steps).should.be.eql(['/step1', '/step2']);
+            });
+        });
+    });
+
+});

--- a/test/util/spec.helpers.js
+++ b/test/util/spec.helpers.js
@@ -2,116 +2,64 @@ var helpers = require('../../lib/util/helpers');
 
 describe('helpers', function () {
 
-    describe('getPreviousSteps', function () {
-        var getPreviousSteps, steps;
+    describe('getRouteSteps', function () {
+        var getRouteSteps, steps;
 
         beforeEach(function () {
-            getPreviousSteps = helpers.getPreviousSteps;
+            getRouteSteps = helpers.getRouteSteps;
+            steps = {
+                '/step1': {
+                    next: '/step2'
+                },
+                '/step2': {
+                    next: '/step3'
+                },
+                '/step2a': {
+                    next: '/step3'
+                },
+                '/step3': {
+                    next: '/step4',
+                    forks: [
+                        { target: '/step5' }
+                    ]
+                },
+                '/step4': {
+                    next: '/step5',
+                    forks: [
+                        { target: '/step6' }
+                    ]
+                },
+                '/step5': {
+                    forks: [
+                        { target: '/step6' }
+                    ]
+                },
+                '/step6': {},
+                '/orphan': {}
+            };
         });
 
         it('is a function', function () {
-            getPreviousSteps.should.be.a('function');
+            getRouteSteps.should.be.a('function');
         });
 
         it('returns an array', function () {
-            getPreviousSteps().should.be.an('array');
+            getRouteSteps().should.be.an('array');
         });
 
-        describe('only using next property', function () {
-            beforeEach(function () {
-                steps = {
-                    '/step1': {
-                        next: '/step2'
-                    },
-                    '/step2': {
-                        next: '/step3'
-                    },
-                    '/step3': {
-                        next: '/step4'
-                    },
-                    '/step3a': {
-                        next: '/step4'
-                    },
-                    '/step4': {}
-                };
-            });
-
-            it('returns /step3a and /step3 when called with steps object and /step4', function () {
-                getPreviousSteps('/step4', steps).should.be.eql(['/step3', '/step3a']);
-            });
-
-            it('should return an empty array if step isn\'t linked to', function () {
-                getPreviousSteps('/step5', steps).should.be.an('array')
-                  .and.have.property('length')
-                  .and.equal(0);
-            });
+        it('returns an empty array when there are no matching previous steps', function () {
+            getRouteSteps('/orphan', steps).should.eql([]);
         });
 
-        describe('using forks', function () {
-            beforeEach(function () {
-              steps = {
-                  '/step1': {
-                      forks: [{
-                        target: '/step2'
-                      }]
-                  },
-                  '/step2': {
-                      forks: [{
-                        target: '/step3'
-                      }, {
-                        target: '/step4'
-                      }]
-                  },
-                  '/step3': {
-                      forks: [{
-                        target: '/step3a'
-                      }]
-                  },
-                  '/step3a': {
-                      forks: [{
-                        target: '/step4'
-                      }]
-                  },
-                  '/step4': {}
-              };
-            });
-
-            it('should return a step that has route as a fork target', function () {
-                getPreviousSteps('/step2', steps).should.be.eql(['/step1']);
-            })
-
-            it('should return all steps that have given step as fork target', function () {
-                getPreviousSteps('/step4', steps).should.be.eql(['/step2', '/step3a']);
-            });
+        it('returns an array of all routes from `next` and `forks` properties', function () {
+            // next
+            getRouteSteps('/step3', steps).should.eql(['/step2', '/step2a']);
+            // next and forks
+            getRouteSteps('/step5', steps).should.eql(['/step3', '/step4']);
+            // forks
+            getRouteSteps('/step6', steps).should.eql(['/step4', '/step5']);
         });
 
-        describe('using next property and forks', function () {
-            beforeEach(function () {
-                steps = {
-                    '/step1': {
-                        next: '/step2',
-                        forks: [{
-                          target: '/step3'
-                        }]
-                    },
-                    '/step2': {
-                        next: '/step3',
-                        forks: [{
-                          target: '/step3a'
-                        }, {
-                          target: '/step4'
-                        }]
-                    },
-                    '/step3': {},
-                    '/step3a': {},
-                    '/step4': {}
-                }
-            });
-
-            it('should return all steps that link to route', function () {
-                getPreviousSteps('/step3', steps).should.be.eql(['/step1', '/step2']);
-            });
-        });
     });
 
 });


### PR DESCRIPTION
If a step is reached by taking a fork, the back-links middleware doesn't recognise this as it only checks the 'next' property to pick up paths to a step.

Forks should be included in the previousSteps variable at the top of the middleware.

* Include forks in previousSteps variable which is checked against step history