### PR TITLE
Remove step from sessionModel if all fields are invalidated

### DIFF
--- a/lib/middleware/check-progress.js
+++ b/lib/middleware/check-progress.js
@@ -27,6 +27,35 @@ module.exports = function checkProgress(route, controller, steps, start) {
         return s;
     };
 
+    /*
+     * Utility function which accepts an array of invalidating fields
+     * and the steps config object, returns a filtered steps object
+     * containing fields which have been invalidated.
+     */
+    var getStepsToCheck = function getStepsToCheck(fields, steps) {
+        return _.pick(steps, function (step) {
+            if (!step.fields) {
+                return false;
+            }
+            return _.intersection(step.fields, fields).length;
+        });
+    };
+
+    /*
+     * Utility function which accepts an array of invalidating fields,
+     * the steps config object and the sessionModel. It returns an array
+     * of step names for which all fields have been invalidated.
+     */
+    var getInvalidatedSteps = function getInvalidatedSteps(fields, steps, sessionModel) {
+        var stepsToCheck = getStepsToCheck(fields, steps);
+
+        return _.chain(stepsToCheck).pick(function (step) {
+            return _.every(step.fields, function (item) {
+                return sessionModel.get(item) === undefined;
+            });
+        }).keys().value();
+    };
+
     var laterSteps = getLaterSteps(route);
 
     controller.on('complete', function (req, res, path) {
@@ -50,8 +79,9 @@ module.exports = function checkProgress(route, controller, steps, start) {
             req.sessionModel.on('change:' + key, function () {
                 debug('Unsetting fields %s', field.invalidates.join(', '));
                 req.sessionModel.unset(field.invalidates);
-                var steps = _.difference(req.sessionModel.get('steps'), laterSteps);
-                req.sessionModel.set('steps', steps);
+                var stepNames = _.difference(req.sessionModel.get('steps'), laterSteps);
+                var invalidatedSteps = getInvalidatedSteps(field.invalidates, steps, req.sessionModel);
+                req.sessionModel.set('steps', _.difference(stepNames, invalidatedSteps));
             });
         });
 


### PR DESCRIPTION
* When a field is invalidated, the step containing the field is checked to see if all fields are invalidated
* If so the step is removed from sessionModel.get('steps') as is effectively no longer a part of the step history.
* This is mainly beneficial in forms that contain forked paths which invalidate other fields/steps