### PR TITLE
Implicitly create backLinks relative to the domain name when baseUrl …

### DIFF
--- a/lib/middleware/back-links.js
+++ b/lib/middleware/back-links.js
@@ -12,8 +12,10 @@ module.exports = function backLink(route, controller, steps) {
         var matchingPath = _.find(controller.options.backLinks, function (link) {
             if (link.match(/^\//)) {
                 return path.normalize(link) === referrerPath;
-            } else {
+            } else if (path.relative(baseUrl, referrerPath)) {
                 return path.normalize(link) === path.relative(baseUrl, referrerPath);
+            } else if (referrerPath.replace(/^\//, '') === link.replace(/^\.*\//, '')) {
+                return path.normalize(link);
             }
         });
         if (typeof matchingPath === 'string') {
@@ -45,7 +47,7 @@ module.exports = function backLink(route, controller, steps) {
         if (typeof controller.options.backLink !== 'undefined') {
             return controller.options.backLink;
         } else if (previous.length) {
-            backLink = _.last(previous).replace(/^\//, '');
+            backLink = req.baseUrl === '/' ? _.last(previous) : _.last(previous).replace(/^\//, '');
         } else if (controller.options.backLinks && req.get('referrer')) {
             backLink = checkReferrer(req.get('referrer'), req.baseUrl) || checkFormHistory(req.session);
         }

--- a/test/middleware/spec.back-link.js
+++ b/test/middleware/spec.back-link.js
@@ -81,7 +81,7 @@ describe('Back Links', function () {
     });
 
     it('adds the previous step to res.locals.backLink', function () {
-        req.get.withArgs('referrer').returns('http://example.com/referrer');
+        req.get.withArgs('referrer').returns('http://example.com/referrer/step2');
         req.baseUrl = '/referrer';
         req.sessionModel.set('steps', ['/step1']);
         helpers.getRouteSteps.returns(['/step1']);
@@ -148,7 +148,7 @@ describe('Back Links', function () {
 
     it('supports absolute paths in whitelist', function () {
         req.get.withArgs('referrer').returns('http://example.com/whitelist');
-        req.baseUrl = '/whitelist';
+        req.baseUrl = '/base';
         req.sessionModel.set('steps', ['/step1', '/step2']);
         controller.options.backLinks = ['/whitelist'];
         backLinks('/step3', controller, steps)(req, res, next);
@@ -175,7 +175,6 @@ describe('Back Links', function () {
 
     it('returns undefined if referrer header is not on whitelist', function () {
         req.get.withArgs('referrer').returns('http://example.com/not-whitelisted');
-        req.baseUrl = '/not-whitelisted';
         req.sessionModel.set('steps', ['/step1', '/step2']);
         controller.options.backLinks = ['whitelist'];
         backLinks('/', controller, steps)(req, res, next);
@@ -184,7 +183,7 @@ describe('Back Links', function () {
 
     it('permits whitelisting of steps from a separate form instance', function () {
         req.get.withArgs('referrer').returns('http://example.com/referrer');
-        req.baseUrl = '/referrer';
+        req.baseUrl = '/other';
         req.sessionModel.set('steps', ['/step1', '/step2', '/step3', '/step4']);
         req.session['hmpo-wizard-test-form'] = { steps: ['/history1', '/history2']};
         controller.options.backLinks = ['./history1'];


### PR DESCRIPTION
…is a slash Resolves #61

This commit allows a user to use `/` for the services baseUrl and get generated backLinks relative to the domain name