### PR TITLE
Invalidation bugfix

### DIFF
--- a/lib/middleware/check-progress.js
+++ b/lib/middleware/check-progress.js
@@ -18,7 +18,7 @@ module.exports = function checkProgress(route, controller, steps, start) {
         var potentialPaths = _.pluck(controller.options.forks, 'target')
             .concat(controller.options.next);
 
-        var nextStep = controller.getNextStep(req, res);
+        var nextStep = controller.getNextStep(req, res).replace(/\/edit$/, '');
         if (req.baseUrl !== '/') {
             nextStep = nextStep.replace((new RegExp('^' + req.baseUrl)), '');
         }

--- a/test/middleware/spec.check-progress.js
+++ b/test/middleware/spec.check-progress.js
@@ -151,6 +151,11 @@ describe('middleware/check-session', function () {
                     'fork-field-2'
                 );
             });
+
+            it('ignores /edit if appended to nextStep', function () {
+                controller.getNextStep = sinon.stub().returns('/fork1/edit');
+                req.sessionModel.get('steps').should.be.eql(sessionSteps);
+            });
         });
 
         describe('when a step is skipped', function () {


### PR DESCRIPTION
HOF Controllers Base Controller appends /edit to the next step if visited from the confirm step, this results in all steps being invalidated as the current logic searches including the /edit