### PR TITLE
closes #69 - allow missing template path

### DIFF
--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -7,7 +7,6 @@ var count = 0;
 var Wizard = function (steps, fields, settings) {
 
     settings = _.extend({
-        templatePath: 'pages',
         params: '',
         controller: Form
     }, settings || {});
@@ -37,7 +36,9 @@ var Wizard = function (steps, fields, settings) {
 
         // default template is the same as the pathname
         options.template = options.template || route.replace(/^\//, '');
-        options.template = settings.templatePath + '/' + options.template;
+        if (settings.templatePath) {
+            options.template = settings.templatePath + '/' + options.template;
+        }
 
         var Controller = options.controller || settings.controller;
 

--- a/test/spec.wizard.js
+++ b/test/spec.wizard.js
@@ -4,7 +4,47 @@ describe('Form Wizard', function () {
 
     var wizard,
         requestHandler,
-        req, res, next;
+        req, res, next,
+        obj;
+
+    describe('settings', function () {
+
+        beforeEach(function () {
+            obj = {
+                controller: StubController()
+            };
+            sinon.spy(obj, 'controller');
+            wizard = Wizard({
+                '/': {
+                    template: 'template',
+                    controller: obj.controller
+                }
+            }, {}, { templatePath: '/a/path' });
+        });
+
+        it('initialises a new controller', function () {
+            obj.controller.should.have.been.calledOnce;
+        });
+
+        it('prepends templatePath to the tempate', function () {
+            obj.controller.should.have.been.calledWithMatch({
+                template: '/a/path/template'
+            });
+        });
+
+        it('doesn\'t prepend template path if omitted', function () {
+            wizard = Wizard({
+                '/': {
+                    template: 'template',
+                    controller: obj.controller
+                }
+            }, {}, {});
+            obj.controller.should.have.been.calledWithMatch({
+                template: 'template'
+            });
+        });
+
+    });
 
     describe('session', function () {
 


### PR DESCRIPTION
This allows the default views directory to be used by express internally

* removed default template path
* check if templatePath if defined before prepending