### PR TITLE
bugfix - fix for infinite loop

### DIFF
--- a/lib/middleware/check-progress.js
+++ b/lib/middleware/check-progress.js
@@ -39,15 +39,16 @@ module.exports = function checkProgress(route, controller, steps, start) {
         sessionModel.set('steps', _.without(sessionModel.get('steps'), stepName));
     };
 
-    var getAllPossibleSteps = function (stepName, steps) {
-        var allSteps = [stepName];
+    var getAllPossibleSteps = function (stepName, steps, allSteps) {
+        allSteps = allSteps || [stepName];
         var step = steps[stepName];
-        while (step && step.next) {
+        // don't loop over steps that have already been added
+        while (step && step.next && allSteps.indexOf(step.next) === -1) {
             allSteps.push(step.next);
             // ignore forks that have already been traversed.
             var forks = _.difference(_.pluck(step.forks, 'target'), allSteps);
             allSteps = allSteps.concat(forks.reduce(function (arr, fork) {
-                return getAllPossibleSteps(fork, steps);
+                return getAllPossibleSteps(fork, steps, allSteps);
             }, []));
             step = steps[step.next];
         }

--- a/test/middleware/spec.check-progress.js
+++ b/test/middleware/spec.check-progress.js
@@ -224,6 +224,14 @@ describe('middleware/check-session', function () {
                         next: '/step3',
                         forks: [{
                             target: '/step1'
+                        }, {
+                            target: '/step3a'
+                        }]
+                    },
+                    '/step3a': {
+                        next: '/step1',
+                        forks: [{
+                            target: '/step3'
                         }]
                     },
                     '/step3': {}


### PR DESCRIPTION
On address lookup step in a multi journey form, it is possible to get into an infinite loop if the fork target is a step that has already been traversed. This is because the top level array of steps was not passed between recursive calls to check step has not been traversed.

* pass allSteps array in getAllPossibleSteps
* check step not already in allSteps before traversing