### PR TITLE
Update to use node 4 as a minimum, update eslint and controller

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,22 +1,25 @@
 {
     "env": {
-        "node": true
+        "node": true,
+        "es6": true
     },
     "extends": "eslint:recommended",
     "rules": {
-        "no-unused-vars": [2, { "argsIgnorePattern": "^(err|req|res|next)$" }],
-        "no-mixed-requires": [2, { "allowCall": true }],
-        "quotes": [2, "single"],
-        "no-trailing-spaces": 2,
-        "indent": 2,
-        "linebreak-style": [2, "unix"],
-        "semi": [2, "always"],
-        "brace-style": [2, "1tbs", { "allowSingleLine": true }],
-        "keyword-spacing": 2,
-        "space-before-blocks": 2,
-        "space-before-function-paren": [2, { "anonymous": "always", "named": "never" }],
-        "no-mixed-spaces-and-tabs": 2,
-        "comma-spacing": [2, {"before": false, "after": true}],
-        "key-spacing": [2, {"beforeColon": false, "afterColon": true}]
+        "no-unused-vars": ["error", { "argsIgnorePattern": "^(err|req|res|next)$" }],
+        "no-mixed-requires": ["error", { "allowCall": true }],
+        "quotes": ["error", "single"],
+        "no-trailing-spaces": "error",
+        "indent": "error",
+        "linebreak-style": ["error", "unix"],
+        "semi": ["error", "always"],
+        "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
+        "keyword-spacing": "error",
+        "space-before-blocks": "error",
+        "space-before-function-paren": ["error", { "anonymous": "always", "named": "never" }],
+        "no-mixed-spaces-and-tabs": "error",
+        "comma-spacing": ["error", {"before": false, "after": true}],
+        "key-spacing": ["error", {"beforeColon": false, "afterColon": true}],
+        "one-var": ["off", { "initialized": "never" }],
+        "no-var": "off"
     }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
+  - "5"
   - "6"
+  - "7"
 notifications:
   email: false
 sudo: false

--- a/package.json
+++ b/package.json
@@ -1,16 +1,14 @@
 {
   "name": "hmpo-form-wizard",
   "version": "5.2.0",
-  "description": "routing and request handling for a multi-step form processes",
+  "description": "Routing and request handling for a multi-step form processes",
   "main": "index.js",
   "scripts": {
-    "test": "npm run lint && npm run unit && npm run cover && npm run check-coverage && npm run snyk",
+    "test": "npm run lint && npm run unit && npm run cover && npm run check-coverage",
     "lint": "eslint .",
     "unit": "mocha test/. --recursive --require test/helpers",
     "cover": "istanbul cover _mocha -- -R dot test/. --recursive --require test/helpers",
-    "check-coverage": "istanbul check-coverage --statement 85.53 --branch 81.58 --function 79.17 --line 86.21",
-    "snyk": "snyk test",
-    "snyk:dev": "snyk test --dev"
+    "check-coverage": "istanbul check-coverage --statement 85.53 --branch 81.58 --function 79.17 --line 86.21"
   },
   "repository": {
     "type": "git",
@@ -18,6 +16,9 @@
   },
   "author": "Leonard Martin <hello@lennym.co.uk>",
   "license": "MIT",
+  "engines": {
+    "node": ">=4"
+  },
   "bugs": {
     "url": "https://github.com/UKHomeOffice/passports-form-wizard/issues"
   },
@@ -26,7 +27,7 @@
     "csrf": "^3.0.2",
     "debug": "^2.1.2",
     "express": "^4.12.2",
-    "hmpo-form-controller": "^0.11.0",
+    "hmpo-form-controller": "^0.12.0",
     "hmpo-model": "^0.7.0",
     "hogan.js": "^3.0.2",
     "i18n-lookup": "^0.1.0",
@@ -34,12 +35,11 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^2.10.2",
+    "eslint": "^3.13.1",
     "istanbul": "^0.4.3",
     "mocha": "^3.1.2",
     "reqres": "^1.2.0",
     "sinon": "^1.14.1",
-    "sinon-chai": "^2.7.0",
-    "snyk": "^1.14.3"
+    "sinon-chai": "^2.7.0"
   }
 }


### PR DESCRIPTION
Update as a breaking change to use a minimum of node 4.
Test against only node 4, 5, 6, and 7
Update to latest eslint and update form controller.
Remove snyk, as it now requires authentication and fails on travis