### PR TITLE
Allow path to be specified in setStepCommplete

### DIFF
--- a/lib/controller/mixins/check-progress.js
+++ b/lib/controller/mixins/check-progress.js
@@ -13,8 +13,8 @@ module.exports = Controller => class extends Controller {
         this.use(this.checkJourneyProgress);
     }
 
-    setStepComplete(req, res) {
-        let path = this.options.route;
+    setStepComplete(req, res, path) {
+        path = path || this.options.route;
         debug('Marking path complete ', path);
 
         let sessionsteps = req.sessionModel.get('steps') || [];

--- a/test/controller/mixins/spec.check-progress.js
+++ b/test/controller/mixins/spec.check-progress.js
@@ -127,6 +127,15 @@ describe('mixins/check-progress', () => {
                 '/two'
             ]);
         });
+
+
+        it('adds custom path step to history if specified', () => {
+            controller.options.route = '/two';
+            controller.setStepComplete(req, res, '/custom/route');
+            req.sessionModel.get('steps').should.deep.equal([
+                '/custom/route'
+            ]);
+        });
     });
 
 });


### PR DESCRIPTION
Allow path to be optionally specified with setStepComplete event and method so that a controller can be overridden to allow a different path to be saved to history.