### PR TITLE
Update wizard to use req.form.options instead of controller.options

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Examples of custom controllers can be found in the [example app](./example/contr
 These controllers can be overridden in a custom controller to provide additional behaviour to a standard controller
 
 ### GET lifecycle
+> #### - `configure(req, res, next)`
+> Allows changing of the `req.form.options` controller options for this request.
 > #### - `get(req, res, next)`
 >> #### - `errors = getErrors(req, res)`
 >> Returns an `Object` of `Controller.Error` validation errors indexed by the field name.
@@ -143,6 +145,8 @@ These controllers can be overridden in a custom controller to provide additional
 >> Renders the template to the user.
 
 ### POST lifecycle
+> #### - `configure(req, res, next)`
+> Allows changing of the `req.form.options` controller options for this request.
 > #### - `post(req, res, next)`
 >> #### - `process(req, res, next)`
 >> Allows for processing the `req.form.values` before validation.
@@ -184,3 +188,7 @@ An example application can be found in [the ./example directory](./example). To 
 * `next` links and error redirects are  now relative to the `baseUrl`.
 * Branching is now supported by `next`. See the Example app for details.
 * The app should provide error middleware that redirects to the location specified by the `redirect` property of the error. This is to allow any error to be intercepted before redirection occurs.
+
+## Migrating to wizard v8
+* Options are deep cloned to `req.form.options` on every request. These can be mutated by overriding the `configure(req, res, next)` method. Tests may need to be updated to make sure `req.form.options` is set to the same object as the controller options when not running the whole request lifecycle.
+* The `noPost` option will now set the step as complete if the `render` method is overridden. Previously this was done by `render`.

--- a/lib/controller/index.js
+++ b/lib/controller/index.js
@@ -25,27 +25,30 @@ class BaseController extends Form {
         this.Error = ErrorClass;
     }
 
-    render(req, res, next) {
-        if (this.options.skip && this.post) {
-            return this.post(req, res, next);
+    _checkStatus(req, res, next) {
+        if (req.form.options.skip) {
+            if (typeof this.post === 'function') {
+                return this.post(req, res, next);
+            }
+            return this.successHandler(req, res, next);
         }
 
         if (typeof this.post !== 'function' && res.locals.nextPage !== req.originalUrl) {
             this.setStepComplete(req, res);
         }
 
-        super.render(req, res, next);
+        next();
     }
 
     errorHandler(err, req, res, next) {
-        if (this.options.skip && this.isValidationError(err)) {
+        if (req.form.options.skip && this.isValidationError(err)) {
             this.setErrors(err, req, res);
             return next(err);
         }
         super.errorHandler(err, req, res, next);
     }
 
-    successHandler(req, res) {
+    successHandler(req, res, next) {
         this.setStepComplete(req, res);
         res.redirect(this.getNextStep(req, res));
     }
@@ -56,7 +59,7 @@ class BaseController extends Form {
         delete json.errors;
         let errs = req.sessionModel.get('errors');
         let errorValues = req.sessionModel.get('errorValues');
-        errorValues = _.pick(errorValues, Object.keys(this.options.fields));
+        errorValues = _.pick(errorValues, Object.keys(req.form.options.fields));
         errorValues = _.pick(errorValues, (e, k) => !errs || !errs[k] || !errs[k].url || errs[k].url === req.path);
         callback(null, _.extend(json, errorValues));
     }
@@ -69,14 +72,14 @@ class BaseController extends Form {
 
     getErrors(req, res) {
         let errs = req.sessionModel.get('errors');
-        errs = _.pick(errs, Object.keys(this.options.fields));
+        errs = _.pick(errs, Object.keys(req.form.options.fields));
         errs = _.pick(errs, e => !e.url || e.url === req.path);
         errs = _.pick(errs, err => !err.redirect );
         return errs;
     }
 
     setErrors(err, req, res) {
-        if (req.form) {
+        if (req.form.values) {
             req.sessionModel.set('errorValues', req.form.values);
         }
         req.sessionModel.set('errors', err);
@@ -107,12 +110,11 @@ class BaseController extends Form {
     middlewareLocals() {
     }
 
-    requestHandler() {
+    middlewareMixins() {
         this.middlewareSetup();
         this.middlewareChecks();
         this.middlewareActions();
         this.middlewareLocals();
-        return super.requestHandler();
     }
 }
 

--- a/lib/controller/mixins/back-links.js
+++ b/lib/controller/mixins/back-links.js
@@ -21,11 +21,11 @@ module.exports = Controller => class extends Controller {
         let backLink;
 
         // if specified in controller options return that
-        if (typeof this.options.backLink !== 'undefined') {
-            return this.resolvePath(req.baseUrl, this.options.backLink);
+        if (typeof req.form.options.backLink !== 'undefined') {
+            return this.resolvePath(req.baseUrl, req.form.options.backLink);
         }
 
-        if (this.options.backLinks) {
+        if (req.form.options.backLinks) {
             return this._backlinksCheckHistory(req, res) ||
                 this._backlinksCheckReferrer(req, res) ||
                 undefined;
@@ -40,12 +40,12 @@ module.exports = Controller => class extends Controller {
     }
 
     _backlinksGetHistoryStep(req, res) {
-        let path = this.resolvePath(req.baseUrl, this.options.route, true);
+        let path = this.resolvePath(req.baseUrl, req.form.options.route, true);
         let journeyHistory = req.journeyModel.get('history') || [];
 
         let item = _.findWhere(journeyHistory, { next: path });
         while (item) {
-            debug('Step has previous in history', this.options.route, item.path);
+            debug('Step has previous in history', req.form.options.route, item.path);
             if (!item.skip) {
                 return item.path;
             }
@@ -60,7 +60,7 @@ module.exports = Controller => class extends Controller {
         // clone reverse history
         journeyHistory = [].concat(journeyHistory).reverse();
 
-        let backLinks = _.map(this.options.backLinks, link => this.resolvePath(req.baseUrl, link));
+        let backLinks = _.map(req.form.options.backLinks, link => this.resolvePath(req.baseUrl, link));
 
         let item = _.find(journeyHistory, item => _.contains(backLinks, item.path));
 
@@ -79,7 +79,7 @@ module.exports = Controller => class extends Controller {
         let referrerPath = url.parse(referrer).path;
 
         let backLink = null;
-        _.find(this.options.backLinks, link => {
+        _.find(req.form.options.backLinks, link => {
             link = this.resolvePath(req.baseUrl, link);
             if (link === referrer || link === referrerPath) {
                 backLink = link;

--- a/lib/controller/mixins/check-progress.js
+++ b/lib/controller/mixins/check-progress.js
@@ -11,14 +11,14 @@ module.exports = Controller => class extends Controller {
     }
 
     checkJourneyProgress(req, res, next) {
-        if (this.options.entryPoint || !this.options.checkJourney) {
+        if (req.form.options.entryPoint || !req.form.options.checkJourney) {
             // don't check this step
             return next();
         }
 
-        let path = this.resolvePath(req.baseUrl, this.options.route, true);
+        let path = this.resolvePath(req.baseUrl, req.form.options.route, true);
 
-        if (this.options.reset) {
+        if (req.form.options.reset) {
             this.removeJourneyHistoryStep(req, res, path);
         }
 
@@ -32,7 +32,7 @@ module.exports = Controller => class extends Controller {
         }
 
         // this is allowed by a prereq
-        let allowedPrereq = _.find(this.options.prereqs, prereq => {
+        let allowedPrereq = _.find(req.form.options.prereqs, prereq => {
             prereq = this.resolvePath(req.baseUrl, prereq);
             return _.findWhere(journeyHistory, { path: prereq });
         });
@@ -54,16 +54,16 @@ module.exports = Controller => class extends Controller {
     }
 
     setStepComplete(req, res, path) {
-        path = this.resolvePath(req.baseUrl, path || this.options.route, true);
+        path = this.resolvePath(req.baseUrl, path || req.form.options.route, true);
         let nextStep = this.getNextStepObject(req, res);
         let next = this.resolvePath(req.baseUrl, nextStep.url);
-        let continueOnEdit = (nextStep.condition && nextStep.condition.continueOnEdit) || this.options.continueOnEdit;
+        let continueOnEdit = (nextStep.condition && nextStep.condition.continueOnEdit) || req.form.options.continueOnEdit;
 
         let newItem = {
             path,
             next,
             fields: nextStep.fields && nextStep.fields.length ? nextStep.fields : undefined,
-            skip: this.options.skip,
+            skip: req.form.options.skip,
             continueOnEdit: req.isEditing ? continueOnEdit :  undefined
         };
 

--- a/lib/controller/mixins/check-session.js
+++ b/lib/controller/mixins/check-session.js
@@ -8,11 +8,11 @@ module.exports = Controller => class extends Controller {
     }
 
     checkSession(req, res, next) {
-        if (!this.options.checkSession) {
+        if (!req.form.options.checkSession) {
             return next();
         }
 
-        if (req.method === 'POST' || !this.options.entryPoint) {
+        if (req.method === 'POST' || !req.form.options.entryPoint) {
             if (req.cookies['hmpo-wizard-sc'] && !req.session.exists) {
                 let err = new Error('Session expired');
                 err.code = 'SESSION_TIMEOUT';

--- a/lib/controller/mixins/csrf.js
+++ b/lib/controller/mixins/csrf.js
@@ -14,9 +14,7 @@ module.exports = Controller => class extends Controller {
 
     middlewareChecks() {
         super.middlewareChecks();
-        if (this.options.csrf !== false) {
-            this.use(this.csrfCheckToken);
-        }
+        this.use(this.csrfCheckToken);
     }
 
     middlewareLocals() {
@@ -38,6 +36,10 @@ module.exports = Controller => class extends Controller {
     }
 
     csrfCheckToken(req, res, next) {
+        if (req.form.options.csrf === false) {
+            return next();
+        }
+
         if (_.contains(safeMethods, req.method)) {
             return next();
         }

--- a/lib/controller/mixins/edit-step.js
+++ b/lib/controller/mixins/edit-step.js
@@ -7,7 +7,7 @@ module.exports = Controller => class extends Controller {
     editing(req, res, next) {
         req.isEditing = true;
         res.locals.isEditing = true;
-        res.locals.editSuffix = this.options.editSuffix;
+        res.locals.editSuffix = req.form.options.editSuffix;
         next();
     }
 
@@ -20,10 +20,10 @@ module.exports = Controller => class extends Controller {
 
         let previousStep = _.find(req.journeyModel.get('history'), { path: backLink });
         if (previousStep && previousStep.continueOnEdit) {
-            return backLink + this.options.editSuffix;
+            return backLink + req.form.options.editSuffix;
         }
 
-        return this.resolvePath(req.baseUrl, this.options.editBackStep);
+        return this.resolvePath(req.baseUrl, req.form.options.editBackStep);
     }
 
     getNextStep(req, res) {
@@ -34,12 +34,12 @@ module.exports = Controller => class extends Controller {
         let nextStep = this.getNextStepObject(req, res);
 
         if (nextStep.url) {
-            if ((nextStep.condition && nextStep.condition.continueOnEdit) || (!nextStep.condition && this.options.continueOnEdit)) {
-                return this.resolvePath(req.baseUrl, nextStep.url + this.options.editSuffix);
+            if ((nextStep.condition && nextStep.condition.continueOnEdit) || (!nextStep.condition && req.form.options.continueOnEdit)) {
+                return this.resolvePath(req.baseUrl, nextStep.url + req.form.options.editSuffix);
             }
         }
 
-        return this.resolvePath(req.baseUrl, this.options.editBackStep);
+        return this.resolvePath(req.baseUrl, req.form.options.editBackStep);
     }
 
 };

--- a/lib/controller/mixins/invalidate-fields.js
+++ b/lib/controller/mixins/invalidate-fields.js
@@ -14,7 +14,7 @@ module.exports = Controller => class extends Controller {
     invalidateFields(req, res, next) {
         // get fields used by this step that invalidate other fields
         let invalidatingFields = _.pick(
-            _.mapObject(this.options.fields, f => f.invalidates),
+            _.mapObject(req.form.options.fields, f => f.invalidates),
             f => f && f.length
         );
         debug('Invalidating fields', invalidatingFields);
@@ -22,7 +22,7 @@ module.exports = Controller => class extends Controller {
         // get steps that could be invalidated by each field
         let invalidatingFieldSteps = _.pick(
             _.mapObject(invalidatingFields,
-                invalidates => _.keys(_.pick(this.options.steps,
+                invalidates => _.keys(_.pick(req.form.options.steps,
                     step => _.intersection(_.keys(step.fields), invalidates).length
                 ))
             ),

--- a/lib/controller/mixins/invalidate-journey.js
+++ b/lib/controller/mixins/invalidate-journey.js
@@ -25,7 +25,7 @@ module.exports = Controller => class extends Controller {
         let journeyHistory = req.journeyModel.get('history') || [];
 
         // find the index of the current step in the history
-        let path = this.resolvePath(req.baseUrl, this.options.route, true);
+        let path = this.resolvePath(req.baseUrl, req.form.options.route, true);
         let itemIndex = _.findIndex(journeyHistory, { path: path });
         if (itemIndex < 0) {
             return;
@@ -42,7 +42,7 @@ module.exports = Controller => class extends Controller {
         }
 
         let invalidated = journeyHistory.splice(historyIndex);
-        debug('Journey truncated', this.options.route, changes, invalidated[0]);
+        debug('Journey truncated', req.form.options.route, changes, invalidated[0]);
         req.journeyModel.set('history', journeyHistory);
     }
 };

--- a/lib/controller/mixins/journey-model.js
+++ b/lib/controller/mixins/journey-model.js
@@ -20,10 +20,10 @@ module.exports = Controller => class extends Controller {
 
         req.journeyModel = new Model(null, {
             session: req.session,
-            key: 'hmpo-journey-' + this.options.journeyName
+            key: 'hmpo-journey-' + req.form.options.journeyName
         });
 
-        if (this.options.resetJourney) {
+        if (req.form.options.resetJourney) {
             req.journeyModel.reset();
         }
 

--- a/lib/controller/mixins/next-step.js
+++ b/lib/controller/mixins/next-step.js
@@ -90,7 +90,7 @@ module.exports = Controller => class extends Controller {
     }
 
     getNextStepObject(req, res) {
-        return this.decodeConditions(req, res, this.options.next);
+        return this.decodeConditions(req, res, req.form.options.next);
     }
 
     getNextStep(req, res) {
@@ -100,7 +100,7 @@ module.exports = Controller => class extends Controller {
             return this.resolvePath(req.baseUrl, nextStep.url);
         }
 
-        return this.resolvePath(req.baseUrl, this.options.route, true);
+        return this.resolvePath(req.baseUrl, req.form.options.route, true);
     }
 
     getErrorStep(err, req, res) {

--- a/lib/controller/mixins/session-model.js
+++ b/lib/controller/mixins/session-model.js
@@ -20,10 +20,10 @@ module.exports = Controller => class extends Controller {
 
         req.sessionModel = new Model(null, {
             session: req.session,
-            key: 'hmpo-wizard-' + this.options.name
+            key: 'hmpo-wizard-' + req.form.options.name
         });
 
-        if (this.options.reset) {
+        if (req.form.options.reset) {
             req.sessionModel.reset();
         }
 

--- a/lib/controller/mixins/translate.js
+++ b/lib/controller/mixins/translate.js
@@ -8,8 +8,8 @@ module.exports = Controller => class extends Controller {
     }
 
     setTranslateEngine(req, res, next) {
-        if (typeof this.options.translate === 'function') {
-            req.translate = this.options.translate;
+        if (typeof req.form.options.translate === 'function') {
+            req.translate = req.form.options.translate;
         }
         next();
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "csrf": "^3.0.2",
     "debug": "^2.1.2",
     "express": "^4.12.2",
-    "hmpo-form-controller": "^1.0.0",
+    "hmpo-form-controller": "^1.1.0",
     "hmpo-model": "^1.0.0",
     "hogan.js": "^3.0.2",
     "i18n-lookup": "^0.1.0",

--- a/test/controller/mixins/spec.back-links.js
+++ b/test/controller/mixins/spec.back-links.js
@@ -13,11 +13,12 @@ describe('mixins/back-links', () => {
         BaseController = baseController();
         BaseController = resolvePath(BaseController);
         StubController = backLinks(BaseController);
-        controller = new StubController({
-            route: '/'
-        });
+
+        let options = { route: '/' };
+        controller = new StubController(options);
 
         req = request({
+            form: { options },
             method: 'GET',
             baseUrl: '/base'
         });

--- a/test/controller/mixins/spec.check-progress.js
+++ b/test/controller/mixins/spec.check-progress.js
@@ -10,7 +10,15 @@ describe('mixins/check-progress', () => {
     let req, res, next, controller;
 
     beforeEach(() => {
+        let options = {
+            checkJourney: true,
+            route: '/teststep',
+            template: 'template',
+            next: 'nextstep'
+        };
+
         req = request({
+            form: { options },
             baseUrl: '/base'
         });
         res = response();
@@ -19,12 +27,7 @@ describe('mixins/check-progress', () => {
         BaseController = baseController();
         BaseController = resolvePath(BaseController);
         StubController = checkProgress(BaseController);
-        controller = new StubController({
-            checkJourney: true,
-            route: '/teststep',
-            template: 'template',
-            next: 'nextstep'
-        });
+        controller = new StubController(options);
     });
 
     it('should export a function', () => {

--- a/test/controller/mixins/spec.check-session.js
+++ b/test/controller/mixins/spec.check-session.js
@@ -8,7 +8,13 @@ describe('mixins/check-session', () => {
     let req, res, next, controller;
 
     beforeEach(() => {
+        let options = {
+            checkSession: true,
+            route: '/route'
+        };
+
         req = request({
+            form: { options },
             path: '/test',
             method: 'GET',
             cookies: {
@@ -23,11 +29,7 @@ describe('mixins/check-session', () => {
 
         BaseController = baseController();
         StubController = checkSession(BaseController);
-        controller = new StubController({
-            checkSession: true,
-            route: '/route'
-        });
-
+        controller = new StubController(options);
     });
 
     it('should export a function', () => {

--- a/test/controller/mixins/spec.edit-step.js
+++ b/test/controller/mixins/spec.edit-step.js
@@ -10,7 +10,13 @@ describe('mixins/edit-step', () => {
     let req, res, next, controller;
 
     beforeEach(() => {
+        let options = {
+            editSuffix: '/editsuffix',
+            editBackStep: 'backstep'
+        };
+
         req = request({
+            form: { options },
             baseUrl: '/base/url'
         });
         res = response();
@@ -19,10 +25,7 @@ describe('mixins/edit-step', () => {
         BaseController = baseController();
         BaseController = resolvePath(BaseController);
         StubController = editStep(BaseController);
-        controller = new StubController({
-            editSuffix: '/editsuffix',
-            editBackStep: 'backstep',
-        });
+        controller = new StubController(options);
 
         BaseController.prototype.getNextStep = sinon.stub().returns('/base/nextstep');
         BaseController.prototype.getBackLink = sinon.stub().returns('/base/backlink');

--- a/test/controller/mixins/spec.invalidate-fields.js
+++ b/test/controller/mixins/spec.invalidate-fields.js
@@ -10,19 +10,6 @@ describe('mixins/invalidate-fields', () => {
     let req, res, next, controller, steps;
 
     beforeEach(() => {
-        req = request({
-            baseUrl: '/base'
-        });
-        res = response();
-        next = sinon.stub();
-
-        req.sessionModel.set({
-            'field1': true,
-            'field2': true,
-            'field3': true,
-            'field4': true
-        });
-
         steps = {
             '/step1': {
                 route: '/step1'
@@ -35,14 +22,30 @@ describe('mixins/invalidate-fields', () => {
             }
         };
 
-        BaseController = baseController();
-        BaseController = resolvePath(BaseController);
-        StubController = invalidateFields(BaseController);
-        controller = new StubController({
+        let options = {
             route: '/step1',
             steps,
             fields: steps['/step1'].fields
+        };
+
+        req = request({
+            form: { options },
+            baseUrl: '/base'
         });
+        res = response();
+        next = sinon.stub();
+
+        req.sessionModel.set({
+            'field1': true,
+            'field2': true,
+            'field3': true,
+            'field4': true
+        });
+
+        BaseController = baseController();
+        BaseController = resolvePath(BaseController);
+        StubController = invalidateFields(BaseController);
+        controller = new StubController(options);
         controller.removeJourneyHistoryStep = sinon.stub();
     });
 

--- a/test/controller/mixins/spec.invalidate-journey.js
+++ b/test/controller/mixins/spec.invalidate-journey.js
@@ -10,7 +10,12 @@ describe('mixins/invalidate-journey', () => {
     let req, res, next, controller;
 
     beforeEach(() => {
+        let options = {
+            route: '/one'
+        };
+
         req = request({
+            form: { options },
             baseUrl: '/'
         });
         res = response();
@@ -19,9 +24,7 @@ describe('mixins/invalidate-journey', () => {
         BaseController = baseController();
         BaseController = resolvePath(BaseController);
         StubController = invalidateJourney(BaseController);
-        controller = new StubController({
-            route: '/one'
-        });
+        controller = new StubController(options);
 
         req.journeyModel.set('history', [
             { path: '/one' },

--- a/test/controller/mixins/spec.journey-model.js
+++ b/test/controller/mixins/spec.journey-model.js
@@ -10,17 +10,20 @@ describe('mixins/journey-model', () => {
     let req, res, next, controller;
 
     beforeEach(() => {
-        req = request();
+        let  options = {
+            name: 'Wizard-Name',
+            journeyName: 'Journey-Name'
+        };
+        req = request({
+            form: { options }
+        });
         delete req.journeyModel;
         res = response();
         next = sinon.stub();
 
         BaseController = baseController();
         StubController = journeyModel(BaseController);
-        controller = new StubController({
-            name: 'Wizard-Name',
-            journeyName: 'Journey-Name'
-        });
+        controller = new StubController(options);
     });
 
     it('should export a function', () => {

--- a/test/controller/mixins/spec.next-step.js
+++ b/test/controller/mixins/spec.next-step.js
@@ -10,7 +10,13 @@ describe('mixins/next-step', () => {
     let req, res, controller;
 
     beforeEach(() => {
+        let options = {
+            route: '/step1',
+            next: 'nextstep'
+        };
+
         req = request({
+            form: { options },
             baseUrl: '/base',
             path: '/request/path'
         });
@@ -19,10 +25,7 @@ describe('mixins/next-step', () => {
         BaseController = baseController();
         BaseController = resolvePath(BaseController);
         StubController = nextStepMixin(BaseController);
-        controller = new StubController({
-            route: '/step1',
-            next: 'nextstep'
-        });
+        controller = new StubController(options);
     });
 
     it('should export a function', () => {

--- a/test/controller/mixins/spec.session-model.js
+++ b/test/controller/mixins/spec.session-model.js
@@ -10,16 +10,19 @@ describe('mixins/session-model', () => {
     let req, res, next, controller;
 
     beforeEach(() => {
-        req = request();
+        let options = {
+            name: 'Wizard-Name'
+        };
+        req = request({
+            form: { options }
+        });
         delete req.sessionModel;
         res = response();
         next = sinon.stub();
 
         BaseController = baseController();
         StubController = sessionModel(BaseController);
-        controller = new StubController({
-            name: 'Wizard-Name'
-        });
+        controller = new StubController(options);
     });
 
     it('should export a function', () => {

--- a/test/controller/mixins/spec.translate.js
+++ b/test/controller/mixins/spec.translate.js
@@ -9,13 +9,16 @@ describe('mixins/translate', () => {
     let req, res, next, controller;
 
     beforeEach(() => {
-        req = request();
+        let options = {};
+        req = request({
+            form: { options }
+        });
         res = response();
         next = sinon.stub();
 
         BaseController = baseController();
         StubController = translate(BaseController);
-        controller = new StubController();
+        controller = new StubController(options);
     });
 
     it('should export a function', () => {


### PR DESCRIPTION
- Change middleware and controller to use req.form.options instead of controller.options
- Move complete step on GET to override _checkStatus instead of render
- Override new middlewareMixins method for middleware setup instead of overriding requestHandler
