### PR TITLE
RFC: Import data from other wizards

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Any of these options can also be provided as a third argument to the wizard to c
 * `invalidates` - an array of field names that will be 'invalidated' when this field value is set or changed. Any fields specified in the `invalidates` array will be removed from the `sessionModel`. Further to this any future steps from the invalidating step field will be removed from the `journeyModel` history.
 * `translate` - provide a function for translating validation error codes into usable messages. Previous implementations have used [i18next](https://www.npmjs.com/package/i18next) to do translations.
 * `params` - Define express parameters for the route for supporting additional URL parameters.
+* `import` - Define fields to import from other wizards. Should be an object specifying which fields are required. eg `imports: { age: true, name: false }`
 
 Remaining field options documentation can be found in the hmpo-template-mixins [README](https://github.com/UKHomeOffice/passports-template-mixins#options-1).
 

--- a/lib/controller/index.js
+++ b/lib/controller/index.js
@@ -130,6 +130,7 @@ Controller = require('./mixins/check-session')(Controller);
 Controller = require('./mixins/check-progress')(Controller);
 Controller = require('./mixins/csrf')(Controller);
 Controller = require('./mixins/invalidate-fields')(Controller);
+Controller = require('./mixins/import')(Controller);
 Controller = require('./mixins/back-links')(Controller);
 Controller = require('./mixins/next-step')(Controller);
 Controller = require('./mixins/edit-step')(Controller);

--- a/lib/controller/mixins/import.js
+++ b/lib/controller/mixins/import.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const _ = require('underscore');
+const debug = require('debug')('hmpo:import');
+
+module.exports = Controller => class extends Controller {
+
+    middlewareChecks() {
+        super.middlewareChecks();
+        this.use(this.importJourneyData);
+    }
+
+    importJourneyData(req, res, next) {
+        if (req.form.options.import) {
+            let imports = {};
+            let missing = [];
+            let dataSources = req.journeyModel.get('dataSources') || {};
+            _.each(req.form.options.import, (options, field) => {
+                if (typeof options === 'boolean') {
+                    options = { required: options };
+                }
+                let data = dataSources[field];
+                if (data && data.wizard !== req.form.options.name) {
+                    let wizardModel = req.session['hmpo-wizard-' + data.wizard];
+                    if (wizardModel) {
+                        imports[field] = wizardModel[field];
+                    }
+                }
+
+                if (options.required !== false && typeof imports[field] === 'undefined') {
+                    missing.push(field);
+                }
+            });
+
+            if (missing.length) {
+                let err = new Error('Required imports missing ' + missing.join(', '));
+                err.code = 'MISSING_IMPORT';
+                err.fields = missing;
+                return next(err);
+            }
+
+            req.sessionModel.set(imports);
+        }
+
+        req.sessionModel.on('change', changes => this._recordJourneyData(req, res, changes));
+        next();
+    }
+
+    // invalidate steps after this step where fields were used in branching conditions
+    _recordJourneyData(req, res, changes) {
+        changes = _.keys(_.omit(changes, 'csrf-secret'));
+        if (!changes.length) {
+            return;
+        }
+
+        let dataSources = req.journeyModel.get('dataSources') || {};
+
+        // find the index of the current step in the history
+
+        _.each(changes, field => {
+            let data = dataSources[field];
+            if (!data) {
+                data = {
+                    path: this.resolvePath(req.baseUrl, req.form.options.route, true),
+                    wizard: req.form.options.name
+                };
+                dataSources[field] = data;
+                debug('Data source recorded', req.form.options.route, field, req.form.options.name);
+            }
+        });
+
+        req.journeyModel.set('dataSources', dataSources);
+    }
+
+    getNextStepObject(req, res) {
+        let nextStep = super.getNextStepObject(req, res);
+        let fields = nextStep.fields || [];
+        if (req.form.options.import) {
+            fields = fields.concat(Object.keys(req.form.options.import));
+        }
+        if (fields.length) {
+            nextStep.fields = _.uniq(fields);
+        }
+        return nextStep;
+    }
+};

--- a/test/controller/mixins/spec.import.js
+++ b/test/controller/mixins/spec.import.js
@@ -1,0 +1,248 @@
+'use strict';
+
+const baseController = require('../../helpers/controller');
+const resolvePath = require('../../../lib/controller/mixins/resolve-path');
+const importFields = require('../../../lib/controller/mixins/import');
+
+describe('mixins/invalidate-journey', () => {
+
+    let BaseController, StubController;
+    let req, res, next, controller;
+
+    beforeEach(() => {
+        let options = {
+            route: '/one',
+            name: 'current'
+        };
+
+        req = request({
+            form: { options },
+            baseUrl: '/base',
+            session: {
+                'hmpo-wizard-name': {
+                    field1: 'foo',
+                    field2: 'bar'
+                },
+                'hmpo-wizard-other': {
+                    field3: 'baz'
+                }
+            }
+        });
+        res = response();
+        next = sinon.stub();
+
+        BaseController = baseController();
+        BaseController = resolvePath(BaseController);
+        StubController = importFields(BaseController);
+        controller = new StubController(options);
+
+        req.journeyModel.set('dataSources', {
+            field1: { path: '/base/one', wizard: 'current' },
+            field2: { path: '/base/two', wizard: 'name' },
+            field3: { path: '/other/three', wizard: 'other' }
+        });
+    });
+
+    it('should export a function', () => {
+        importFields.should.be.a.function;
+        importFields.length.should.equal(1);
+    });
+
+    it('should extend a passed controller', () => {
+        controller.should.be.an.instanceOf(BaseController);
+    });
+
+    describe('middlewareChecks override', () => {
+        it('calls the super method', () => {
+            controller.middlewareChecks();
+            BaseController.prototype.middlewareChecks.should.have.been.calledOnce;
+        });
+
+        it('uses the importJourneyData middleware', () => {
+            controller.middlewareChecks();
+            BaseController.prototype.use.should.have.been.calledOnce;
+            BaseController.prototype.use.should.have.been.calledWithExactly(
+                controller.importJourneyData
+            );
+        });
+    });
+
+    describe('importJourneyData', () => {
+        it('adds a changes event to the session model', () => {
+            controller._recordJourneyData = sinon.stub();
+            controller.importJourneyData(req, res, next);
+            req.sessionModel.set({ a: 1, b: 2 });
+            controller._recordJourneyData.should.have.been.calledOnce;
+            controller._recordJourneyData.should.have.been.calledWithExactly(
+                req,
+                res,
+                { a: 1, b: 2 }
+            );
+        });
+
+        it('should call the next callback', () => {
+            controller.importJourneyData(req, res, next);
+            next.should.have.been.calledOnce;
+            next.should.have.been.calledWithExactly();
+        });
+
+        it('should import fields specified in config', () => {
+            req.form.options.import = {
+                'field2': true,
+                'field3': true
+            };
+            controller.importJourneyData(req, res, next);
+            req.sessionModel.get('field2').should.equal('bar');
+            req.sessionModel.get('field3').should.equal('baz');
+        });
+
+        it('should ignore non-existant non-required fields', () => {
+            req.form.options.import = {
+                'field2': true,
+                'field4': { required: false }
+            };
+            controller.importJourneyData(req, res, next);
+            req.sessionModel.get('field2').should.equal('bar');
+            expect(req.sessionModel.get('field3')).to.not.be.ok;
+        });
+
+        it('should return an error for non-existant required fields', () => {
+            req.form.options.import = {
+                'field2': true,
+                'field4': true
+            };
+            controller.importJourneyData(req, res, next);
+            next.should.have.been.calledWithExactly(sinon.match.instanceOf(Error));
+            next.args[0][0].code.should.equal('MISSING_IMPORT');
+        });
+
+        it('should not set any imports if one is missing', () => {
+            req.form.options.import = {
+                'field2': true,
+                'field4': true
+            };
+            controller.importJourneyData(req, res, next);
+            expect(req.sessionModel.get('field1')).to.not.be.ok;
+            expect(req.sessionModel.get('field4')).to.not.be.ok;
+        });
+
+        it('should not set any imports if there are no data sources in history', () => {
+            req.journeyModel.unset('dataSources');
+            req.form.options.import = {
+                'field2': true,
+            };
+            controller.importJourneyData(req, res, next);
+            expect(req.sessionModel.get('field2')).to.not.be.ok;
+        });
+
+        it('should not set any imports if the wizard model is missing', () => {
+            req.journeyModel.set('dataSources', {
+                field1: { path: '/base/one', wizard: 'missing' }
+            });
+            req.form.options.import = {
+                'field1': true
+            };
+            controller.importJourneyData(req, res, next);
+            expect(req.sessionModel.get('field1')).to.not.be.ok;
+        });
+
+        it('should not imports data from itself', () => {
+            req.form.options.import = {
+                'field1': true
+            };
+            controller.importJourneyData(req, res, next);
+            expect(req.sessionModel.get('field1')).to.not.be.ok;
+            next.should.have.been.calledWithExactly(sinon.match.instanceOf(Error));
+            next.args[0][0].code.should.equal('MISSING_IMPORT');
+        });
+    });
+
+    describe('_recordJourneyData', () => {
+        it('should not change the step history if there are no changes', () => {
+            controller._recordJourneyData(req, res, {});
+            req.journeyModel.get('dataSources').should.deep.equal({
+                field1: { path: '/base/one', wizard: 'current' },
+                field2: { path: '/base/two', wizard: 'name' },
+                field3: { path: '/other/three', wizard: 'other' }
+            });
+        });
+
+        it('should create dataSources if it doesn\'t exist', () => {
+            req.journeyModel.unset('dataSources');
+            controller._recordJourneyData(req, res, { field4: 'value' });
+            req.journeyModel.get('dataSources').should.deep.equal({
+                field4: { path: '/base/one', wizard: 'current' }
+            });
+        });
+
+        it('should add field it doesn\'t exist', () => {
+            controller._recordJourneyData(req, res, { field4: 'value' });
+            req.journeyModel.get('dataSources').should.deep.equal({
+                field1: { path: '/base/one', wizard: 'current' },
+                field2: { path: '/base/two', wizard: 'name' },
+                field3: { path: '/other/three', wizard: 'other' },
+                field4: { path: '/base/one', wizard: 'current' }
+            });
+        });
+
+        it('should not add field it exists', () => {
+            controller._recordJourneyData(req, res, { field2: 'value' });
+            req.journeyModel.get('dataSources').should.deep.equal({
+                field1: { path: '/base/one', wizard: 'current' },
+                field2: { path: '/base/two', wizard: 'name' },
+                field3: { path: '/other/three', wizard: 'other' }
+            });
+        });
+    });
+
+    describe('getNextStepObject', () => {
+        beforeEach(() => {
+            BaseController.prototype.getNextStepObject = sinon.stub().returns({
+                url: 'nextstep',
+                fields: [ 'field5', 'field6' ]
+            });
+        });
+
+        it('should add the importing field names to next step field history', () => {
+            req.form.options.import = {
+                'field1': true
+            };
+            let nextStep = controller.getNextStepObject(req, res);
+            nextStep.fields.should.deep.equal([
+                'field5',
+                'field6',
+                'field1'
+            ]);
+        });
+
+        it('should not add duplicate field names to history', () => {
+            req.form.options.import = {
+                'field5': true
+            };
+            let nextStep = controller.getNextStepObject(req, res);
+            nextStep.fields.should.deep.equal([
+                'field5',
+                'field6'
+            ]);
+        });
+
+        it('should only add next step fields if import is not defined', () => {
+            let nextStep = controller.getNextStepObject(req, res);
+            nextStep.fields.should.deep.equal([
+                'field5',
+                'field6'
+            ]);
+        });
+
+        it('should not add any fields property if import is empty and there are no next step fields', () => {
+            req.form.options.import = {};
+            BaseController.prototype.getNextStepObject.returns({
+                url: 'nextstep'
+            });
+            let nextStep = controller.getNextStepObject(req, res);
+            expect(nextStep.fields).to.be.undefined;
+        });
+    });
+
+});
+

--- a/test/controller/spec.index.js
+++ b/test/controller/spec.index.js
@@ -523,6 +523,7 @@ describe('Form Controller', () => {
             'check-progress',
             'csrf',
             'invalidate-fields',
+            'import',
             'back-links',
             'next-step',
             'edit-step'


### PR DESCRIPTION
# Request For Comments
Specify fields to import from other wizards by specifying `import: { field: true }` in step config.

When changing sessionModel values, a record of where they are set is added to the journey model dataSources property. This is used to look up the correct wizard to import the data from. This could be used in future to look up an editing step for a field.

The imported fields are added to the fields in step history in order to invalidate the importing step if they are changed in an earlier step, causing them to imported again.

