### PR TITLE
Adjust hyphens formatter and add singlehyphens

### DIFF
--- a/lib/formatting/formatters.js
+++ b/lib/formatting/formatters.js
@@ -32,8 +32,12 @@ let formatters = {
         return typeof value === 'string' ? value.replace(/\s+/g, ' ') : value;
     },
 
-    hyphens(value) {
+    singlehyphens(value) {
         return typeof value === 'string' ? value.replace(/[–—-]+/g, '-') : value;
+    },
+
+    hyphens(value) {
+        return typeof value === 'string' ? value.replace(/\u2013|\u2014/g, '-') : value;
     },
 
     removeroundbrackets(value) {

--- a/test/formatting/spec.formatters.js
+++ b/test/formatting/spec.formatters.js
@@ -71,11 +71,18 @@ describe('Formatters', () => {
         ' multiple  \t spaces ': ' multiple spaces '
     });
 
-    testStringFormatter('hyphens', {
+    testStringFormatter('singlehyphens', {
         'nohyphen': 'nohyphen',
         'hyphen–one': 'hyphen-one',
         'hyphen—two': 'hyphen-two',
         '-—–—-multiple-—–—-hyphens-—–—-': '-multiple-hyphens-'
+    });
+
+    testStringFormatter('hyphens', {
+        'nohyphen': 'nohyphen',
+        'hyphen–one': 'hyphen-one',
+        'hyphen—two': 'hyphen-two',
+        '-—–—-multiple-—–—-hyphens-—–—-': '-----multiple-----hyphens-----'
     });
 
     testStringFormatter('removeroundbrackets', {


### PR DESCRIPTION
The hyphens formatter will now replace en/em dash unicode hyphens to your standard ascii hyphen. Also a new singlehyphens formatter has been added.