### PR TITLE
Specify what fields to base a revalidation on instead of any decision field

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Any of these options can also be provided as a third argument to the wizard to c
 * `controller` - The constructor for the controller to be used for this step's request handling. The default is exported as a `Controller` property of this module. If custom behaviour is required for a particular form step then custom extensions can be defined - see [Custom Controllers](#custom-controllers)
 * `decisionFields` - Additional fields that we be recorded as being part of this step's routing decision. Default: `[]`
 * `revalidate` - Show this page instead of only recalculating the routing if this page is marked invalid. Default: `false`
+* `revalidateIf` - Show this page instead of only recalculating the routing if one of these values is changed. Default: `[]`
 * `translate` - provide a function for translating validation error codes into usable messages. Previous implementations have used [i18next](https://www.npmjs.com/package/i18next) to do translations.
 * `params` - Define express parameters for the route for supporting additional URL parameters.
 

--- a/lib/controller/mixins/check-progress.js
+++ b/lib/controller/mixins/check-progress.js
@@ -138,6 +138,7 @@ module.exports = Controller => class extends Controller {
         fields = fields.concat(formFields);
         fields = fields.concat(nextStep.fields);
         fields = fields.concat(req.form.options.decisionFields);
+        formFields = formFields.concat(req.form.options.revalidateIf);
 
         let newItem = {
             path,

--- a/test/controller/mixins/spec.check-progress.js
+++ b/test/controller/mixins/spec.check-progress.js
@@ -362,7 +362,7 @@ describe('mixins/check-progress', () => {
             );
         });
 
-        it('appends step fields and decisionFields to form fields', () => {
+        it('appends step fields and decisionFields to fields', () => {
             req.form.options.fields = {
                 f1: {},
                 f2: {},
@@ -390,6 +390,39 @@ describe('mixins/check-progress', () => {
                     next: '/base/nextstep',
                     fields: ['f1', 'j2', 'j3', 'f4', 'd1', 'd2'],
                     formFields: ['f1', 'j2', 'j3'],
+                    wizard: 'wizard'
+                }
+            );
+        });
+
+        it('appends step fields and revalidateIf to formFields', () => {
+            req.form.options.fields = {
+                f1: {},
+                f2: {},
+                f3: {}
+            };
+            req.form.options.allFields = {
+                f1: {},
+                f2: { journeyKey: 'j2' },
+                f3: { journeyKey: 'j3' },
+                f4: {}
+            };
+            req.form.options.revalidateIf = [
+                'd1',
+                'f1',
+                'd2'
+            ];
+            controller.getNextStepObject.returns({
+                url: 'nextstep',
+                fields: ['f1', 'f2', 'f4']
+            });
+            controller.setStepComplete(req, res);
+            controller.addJourneyHistoryStep.args[0][2].should.deep.equal(
+                {
+                    path: '/base/teststep',
+                    next: '/base/nextstep',
+                    fields: ['f1', 'j2', 'j3', 'f4'],
+                    formFields: ['f1', 'j2', 'j3', 'd1', 'd2'],
                     wizard: 'wizard'
                 }
             );


### PR DESCRIPTION
Specify `revalidateIf: [ 'fieldname' ]` instead of decisionFields: [ 'fieldname' ], revalidate: true` to only show the page again if a form field or specified field is changed, instead of if any decision field is changed.