### PR TITLE
Fix typo in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ module.exports = {
     fields: ['age'],
     next: [
       { field: 'age', op: '<', value: 18, next: 'not-old-enough' },
-      next: 'step4'
+      'step4'
     ]
   },
   '/step4': {},


### PR DESCRIPTION
Fixes the syntax in the [Usage example](https://github.com/UKHomeOffice/passports-form-wizard#usage) to use a default string as the last element of an array when the `next` property uses an array as its value.

This updates the *Usage Example* to use the same syntax as shown in [Next Steps](https://www.npmjs.com/package/hmpo-form-wizard#next-steps)