### PR TITLE
Make controller compatible with express versions 4 and 5

### DIFF
--- a/lib/controller/index.js
+++ b/lib/controller/index.js
@@ -67,7 +67,7 @@ class BaseController {
     useWithMethod(method) {
         if (!this.router) throw new Error('Cannot use middleware outside of middleware mixins');
         let args = this._bindFunctions(arguments);
-        args[0] = '*';
+        args[0] = /.*/;
         this.router[method].apply(this.router, args);
     }
 
@@ -425,4 +425,3 @@ Controller.validators = validation.validators;
 Controller.formatters = formatting.formatters;
 
 module.exports = Controller;
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "chai": "^4.5.0",
         "eslint": "^9.12.0",
-        "express": "^4.21.1",
+        "express": "^4.21.2",
         "globals": "^15.11.0",
         "hmpo-reqres": "^2.0.0",
         "husky": "^9.1.6",
@@ -35,7 +35,7 @@
         "node": "20.x || 22.x"
       },
       "peerDependencies": {
-        "express": ">=4",
+        "express": "4 || 5",
         "json5": ">=2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "underscore": "^1.13.7"
   },
   "peerDependencies": {
-    "express": ">=4",
+    "express": "4 || 5",
     "json5": ">=2"
   },
   "devDependencies": {
     "chai": "^4.5.0",
     "eslint": "^9.12.0",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "json5": "^2.2.3",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",

--- a/test/controller/spec.index.js
+++ b/test/controller/spec.index.js
@@ -217,7 +217,7 @@ describe('Form Controller', () => {
             let fn = sinon.stub();
             controller.useWithMethod('get', [fn, [fn, fn, [fn, fn]]]);
             controller.router.get.should.have.been.calledWithExactly(
-                '*',
+                /.*/,
                 sinon.match.func,
                 sinon.match.func,
                 sinon.match.func,


### PR DESCRIPTION
- `express` 4’s router methods allow wildcard paths in the form `'*'`
- `express` 5’s router methods require wildcard placeholders in paths to be named, eg. `'*allPaths'`
- …and there is no wildcard syntax that is common to both. For example, `express` 4 treats `'*allPaths'` as requiring the text “allPaths” to appear in the URL path.

However, both allow specifying a `RegExp` object directly, thereby bypassing the use of differing versions of `path-to-regexp` (which are used under the hood on string paths).

This should address #208 but by different means.