### PR TITLE
DD-749 Update example app dependency for expressjs to fix pathToRegexpError

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ These controllers can be overridden in a custom controller to provide additional
 
 An example application can be found in [the ./example directory](./example). To run this, follow the instructions in the [README](./example/README.md).
 
+> **⚠️ Express Compatibility**: If you encounter a `path-to-regexp` error when running the example app with `"latest"` dependencies, pin Express to a v4.x version in the example's package.json by changing `"express": "latest"` to `"express": "^4.21.2"`. This is due to breaking changes in Express v5.x that affect route parameter parsing.
+
 ## Session Injection
 
 A [helper](./injection/session-injection.js) is provided to aid with session injection:

--- a/example/README.md
+++ b/example/README.md
@@ -1,5 +1,7 @@
 # Example
 
+> **⚠️ Compatibility Note**: If you encounter a `path-to-regexp` error when starting this example, it's likely due to Express v5.x compatibility issues. Pin Express to a v4.x version in package.json by changing `"express": "latest"` to `"express": "^4.21.2"`. This is due to breaking changes in Express v5.x that affect route parameter parsing.
+
 ## Installing and running
 
 ```

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "body-parser": "latest",
     "cookie-parser": "latest",
-    "express": "latest",
+    "express": "^4.21.2",
     "express-session": "latest",
     "govuk-frontend": "latest",
     "hmpo-components": "latest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "chai": "^4.5.0",
         "eslint": "^9.12.0",
-        "express": "^4.21.1",
+        "express": "^4.21.2",
         "globals": "^15.11.0",
         "hmpo-reqres": "^2.0.0",
         "husky": "^9.1.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "chai": "^4.5.0",
     "eslint": "^9.12.0",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "json5": "^2.2.3",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",


### PR DESCRIPTION
Pinned the Express dependency to a v4.x version in the example app as previous "latest" tag was bringing in Express v5.x, which is not compatible with this app yet and was causing a pathToRegexpError, leading to npm start failures. 